### PR TITLE
Make environment scripts work from any directory

### DIFF
--- a/env_analysis.csh
+++ b/env_analysis.csh
@@ -1,8 +1,32 @@
 #!/bin/csh -f
 
-# SET ROOT_ANALYSIS_HOME TO $PWD, IF NOT SET ALREADY
-if ( ! $?ROOT_ANALYSIS_HOME ) then
-	setenv ROOT_ANALYSIS_HOME $PWD
+# SET ROOT_ANALYSIS_HOME
+set ARGS=($_)
+if ("$ARGS" != "") then
+	set GRA_DIR="`dirname ${ARGS[2]}`"
+	set GRA_DIR="`cd ${GRA_DIR}; pwd`"
+else
+	set GRA_DIR=`pwd`
+	if ( ! -e env_analysis.csh && ! $?ROOT_ANALYSIS_HOME ) then
+		echo "Error: Non-interactive usage requires either:"
+		echo "1. cd <path_to_gluex_root_analysis>; source env_analysis.csh"
+		echo "2. Set ROOT_ANALYSIS_HOME before sourcing this script."
+		exit 1
+	endif
+endif
+if ( $?ROOT_ANALYSIS_HOME ) then
+	set GRA_DIR=$ROOT_ANALYSIS_HOME
+endif
+if ( -e ${GRA_DIR}/env_analysis.csh ) then
+	setenv ROOT_ANALYSIS_HOME $GRA_DIR
+else
+	echo "Error: ${GRA_DIR}/env_analysis.csh does not exist."
+	echo "Probable error: Non-interactive usage requires either:"
+	echo "1. cd <path_to_gluex_root_analysis>; source env_analysis.csh"
+	echo "2. Set ROOT_ANALYSIS_HOME before sourcing this script."
+	echo "If you already set ROOT_ANALYSIS_HOME before sourcing this script,"
+	echo "check that it was set to the correct directory."
+	exit 1
 endif
 
 # SET BMS_OSNAME, IF NOT SET ALREADY # COPIED FROM sim-recon
@@ -16,4 +40,3 @@ if ( ! $?LD_LIBRARY_PATH ) then
 endif
 setenv LD_LIBRARY_PATH ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/lib/:$LD_LIBRARY_PATH
 setenv PATH ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/bin/:$PATH
-

--- a/env_analysis.sh
+++ b/env_analysis.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# SET ROOT_ANALYSIS_HOME TO $PWD, IF NOT SET ALREADY
-if [[ $ROOT_ANALYSIS_HOME == "" ]]; then
-	export ROOT_ANALYSIS_HOME=${PWD}
+# SET ROOT_ANALYSIS_HOME
+SCRIPT_PATH=${BASH_SOURCE[0]}
+if [[ -h $SCRIPT_PATH ]]; then
+	SCRIPT_PATH=$(readlink $SCRIPT_PATH)
 fi
+export ROOT_ANALYSIS_HOME=$(cd $(dirname $SCRIPT_PATH); pwd)
 
 # SET BMS_OSNAME, IF NOT SET ALREADY # COPIED FROM sim-recon
 if [[ $BMS_OSNAME == "" ]]; then


### PR DESCRIPTION
Use the path to the environment script to set ROOT_ANALYSIS_HOME. For
C shell, this does not work properly when sourcing the environment
script in another script. One can either change to the script's
directory before sourcing it or set ROOT_ANALYSIS_HOME externally.