### PR TITLE
Fix unknown particle

### DIFF
--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -598,12 +598,26 @@ void DHistogramAction_InvariantMass::Initialize(void)
 	locHistTitle = string(";") + locParticleNamesForHist + string(" Invariant Mass (GeV/c^{2});# Combos / ") + locStream.str() + string(" MeV/c^{2}");
 	dHist_InvaraintMass = new TH1I(locHistName.c_str(), locHistTitle.c_str(), dNumMassBins, dMinMass, dMaxMass);
 
+	locHistName = "InvariantMassVsConfidenceLevel";
+	locHistTitle = string(";Kinematic Fit Confidence Level;") + locParticleNamesForHist + string(" Invariant Mass (GeV/c^{2})");
+	dHist_InvaraintMassVsConfidenceLevel = new TH2I(locHistName.c_str(), locHistTitle.c_str(), dNumConLevBins, 0.0, 1.0, dNum2DMassBins, dMinMass, dMaxMass);
+
+	locHistName = "InvariantMassVsConfidenceLevel_LogX";
+	int locNumBins = 0;
+	double* locConLevLogBinning = dAnalysisUtilities.Generate_LogBinning(dConLevLowest10Power, 0, dNumBinsPerConLevPower, locNumBins);
+	if(locConLevLogBinning != NULL)
+		dHist_InvaraintMassVsConfidenceLevel_LogX = new TH2I(locHistName.c_str(), locHistTitle.c_str(), locNumBins, locConLevLogBinning, dNum2DMassBins, dMinMass, dMaxMass);
+	else
+		dHist_InvaraintMassVsConfidenceLevel_LogX = NULL;
+
 	//Return to the base directory
 	ChangeTo_BaseDirectory();
 }
 
 bool DHistogramAction_InvariantMass::Perform_Action(void)
 {
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+
 	for(size_t loc_i = 0; loc_i < dParticleComboWrapper->Get_NumParticleComboSteps(); ++loc_i)
 	{
 		const DParticleComboStep* locParticleComboStepWrapper = dParticleComboWrapper->Get_ParticleComboStep(loc_i);
@@ -627,6 +641,8 @@ bool DHistogramAction_InvariantMass::Perform_Action(void)
 			dPreviouslyHistogrammed.insert(locSourceObjects);
 
 			dHist_InvaraintMass->Fill(locFinalStateP4.M());
+			dHist_InvaraintMassVsConfidenceLevel->Fill(locConfidenceLevel, locFinalStateP4.M());
+			dHist_InvaraintMassVsConfidenceLevel_LogX->Fill(locConfidenceLevel, locFinalStateP4.M());
 		}
 		//don't break: e.g. if multiple pi0's, histogram invariant mass of each one
 	}
@@ -662,12 +678,26 @@ void DHistogramAction_MissingMass::Initialize(void)
 	locHistTitle = string(";Missing P (GeV/c);") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass (GeV/c^{2})");
 	dHist_MissingMassVsMissingP = new TH2I(locHistName.c_str(), locHistTitle.c_str(), dNum2DMissPBins, dMinMissP, dMaxMissP, dNum2DMassBins, dMinMass, dMaxMass);
 
+	locHistName = "MissingMassVsConfidenceLevel";
+	locHistTitle = string(";Kinematic Fit Confidence Level;") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass (GeV/c^{2})");
+	dHist_MissingMassVsConfidenceLevel = new TH2I(locHistName.c_str(), locHistTitle.c_str(), dNumConLevBins, 0.0, 1.0, dNum2DMassBins, dMinMass, dMaxMass);
+
+	locHistName = "MissingMassVsConfidenceLevel_LogX";
+	int locNumBins = 0;
+	double* locConLevLogBinning = dAnalysisUtilities.Generate_LogBinning(dConLevLowest10Power, 0, dNumBinsPerConLevPower, locNumBins);
+	if(locConLevLogBinning != NULL)
+		dHist_MissingMassVsConfidenceLevel_LogX = new TH2I(locHistName.c_str(), locHistTitle.c_str(), locNumBins, locConLevLogBinning, dNum2DMassBins, dMinMass, dMaxMass);
+	else
+		dHist_MissingMassVsConfidenceLevel_LogX = NULL;
+
 	//Return to the base directory
 	ChangeTo_BaseDirectory();
 }
 
 bool DHistogramAction_MissingMass::Perform_Action(void)
 {
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
 	double locBeamEnergy = 0.0;
 	if(dUseKinFitFlag)
@@ -693,6 +723,8 @@ bool DHistogramAction_MissingMass::Perform_Action(void)
 		dHist_MissingMass->Fill(locMissingP4.M());
 		dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMissingP4.M());
 		dHist_MissingMassVsMissingP->Fill(locMissingP4.P(), locMissingP4.M());
+		dHist_MissingMassVsConfidenceLevel->Fill(locConfidenceLevel, locMissingP4.M());
+		dHist_MissingMassVsConfidenceLevel_LogX->Fill(locConfidenceLevel, locMissingP4.M());
 	}
 
 	return true;
@@ -726,12 +758,26 @@ void DHistogramAction_MissingMassSquared::Initialize(void)
 	locHistTitle = string(";Missing P (GeV/c);") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass Squared (GeV/c^{2})^{2}");
 	dHist_MissingMassVsMissingP = new TH2I(locHistName.c_str(), locHistTitle.c_str(), dNum2DMissPBins, dMinMissP, dMaxMissP, dNum2DMassBins, dMinMass, dMaxMass);
 
+	locHistName = "MissingMassSquaredVsConfidenceLevel";
+	locHistTitle = string(";Kinematic Fit Confidence Level;") + locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName + string(" Missing Mass Squared (GeV/c^{2})^{2}");
+	dHist_MissingMassVsConfidenceLevel = new TH2I(locHistName.c_str(), locHistTitle.c_str(), dNumConLevBins, 0.0, 1.0, dNum2DMassBins, dMinMass, dMaxMass);
+
+	locHistName = "MissingMassSquaredVsConfidenceLevel_LogX";
+	int locNumBins = 0;
+	double* locConLevLogBinning = dAnalysisUtilities.Generate_LogBinning(dConLevLowest10Power, 0, dNumBinsPerConLevPower, locNumBins);
+	if(locConLevLogBinning != NULL)
+		dHist_MissingMassVsConfidenceLevel_LogX = new TH2I(locHistName.c_str(), locHistTitle.c_str(), locNumBins, locConLevLogBinning, dNum2DMassBins, dMinMass, dMaxMass);
+	else
+		dHist_MissingMassVsConfidenceLevel_LogX = NULL;
+
 	//Return to the base directory
 	ChangeTo_BaseDirectory();
 }
 
 bool DHistogramAction_MissingMassSquared::Perform_Action(void)
 {
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
 	double locBeamEnergy = 0.0;
 	if(dUseKinFitFlag)
@@ -757,6 +803,8 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(void)
 		dHist_MissingMass->Fill(locMissingP4.M2());
 		dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMissingP4.M2());
 		dHist_MissingMassVsMissingP->Fill(locMissingP4.P(), locMissingP4.M2());
+		dHist_MissingMassVsConfidenceLevel->Fill(locConfidenceLevel, locMissingP4.M());
+		dHist_MissingMassVsConfidenceLevel_LogX->Fill(locConfidenceLevel, locMissingP4.M());
 	}
 
 	return true;

--- a/libraries/DSelector/DHistogramActions.h
+++ b/libraries/DSelector/DHistogramActions.h
@@ -149,14 +149,16 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 		DHistogramAction_InvariantMass(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, Particle_t locInitialPID, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_InvariantMass", locUseKinFitFlag, locActionUniqueString),
 			dInitialPID(locInitialPID), dStepIndex(-1), dToIncludePIDs(deque<Particle_t>()),
-			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass) {}
+			dNumMassBins(locNumMassBins), dNum2DMassBins(locNumMassBins/2), dMinMass(locMinMass), dMaxMass(locMaxMass),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		//e.g. if g, p -> pi+, pi-, p
 			//call with step = 0, PIDs = pi+, pi-, and will histogram rho mass
 		DHistogramAction_InvariantMass(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_InvariantMass", locUseKinFitFlag, locActionUniqueString),
 			dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs),
-			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass) {}
+			dNumMassBins(locNumMassBins), dNum2DMassBins(locNumMassBins/2), dMinMass(locMinMass), dMaxMass(locMaxMass),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		void Reset_NewEvent(void){dPreviouslyHistogrammed.clear();}; //reset uniqueness tracking
 		void Initialize(void);
@@ -167,11 +169,18 @@ class DHistogramAction_InvariantMass : public DAnalysisAction
 		int dStepIndex;
 		deque<Particle_t> dToIncludePIDs;
 
-		unsigned int dNumMassBins;
+		unsigned int dNumMassBins, dNum2DMassBins;
 		double dMinMass, dMaxMass;
 
+	public:
+		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
+		int dConLevLowest10Power;
+
+	private:
 		DAnalysisUtilities dAnalysisUtilities;
 		TH1I* dHist_InvaraintMass;
+		TH2I* dHist_InvaraintMassVsConfidenceLevel;
+		TH2I* dHist_InvaraintMassVsConfidenceLevel_LogX;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map
@@ -185,7 +194,8 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		DHistogramAction_MissingMass(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0), dMissingMassOffOfPIDs(deque<Particle_t>()),
-			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0) {}
+			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -204,13 +214,15 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(locMissingMassOffOfPIDs),
-			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0) {}
+			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		DHistogramAction_MissingMass(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)),
-			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0) {}
+			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		void Reset_NewEvent(void){dPreviouslyHistogrammed.clear();}; //reset uniqueness tracking
 		void Initialize(void);
@@ -226,10 +238,15 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
 		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
+		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
+		int dConLevLowest10Power;
+
 	private:
 		TH1I* dHist_MissingMass;
 		TH2I* dHist_MissingMassVsBeamE;
 		TH2I* dHist_MissingMassVsMissingP;
+		TH2I* dHist_MissingMassVsConfidenceLevel;
+		TH2I* dHist_MissingMassVsConfidenceLevel_LogX;
 		DAnalysisUtilities dAnalysisUtilities;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
@@ -244,7 +261,8 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		DHistogramAction_MissingMassSquared(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq), dMissingMassOffOfStepIndex(0), dMissingMassOffOfPIDs(deque<Particle_t>()),
-			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0) {}
+			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -263,13 +281,15 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(locMissingMassOffOfPIDs),
-			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0) {}
+			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		DHistogramAction_MissingMassSquared(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)),
-			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0) {}
+			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
 
 		void Reset_NewEvent(void){dPreviouslyHistogrammed.clear();}; //reset uniqueness tracking
 		void Initialize(void);
@@ -285,10 +305,15 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		unsigned int dNum2DMassBins, dNum2DBeamEBins, dNum2DMissPBins;
 		double dMinBeamE, dMaxBeamE, dMinMissP, dMaxMissP;
 
+		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
+		int dConLevLowest10Power;
+
 	private:
 		TH1I* dHist_MissingMass;
 		TH2I* dHist_MissingMassVsBeamE;
 		TH2I* dHist_MissingMassVsMissingP;
+		TH2I* dHist_MissingMassVsConfidenceLevel;
+		TH2I* dHist_MissingMassVsConfidenceLevel_LogX;
 		DAnalysisUtilities dAnalysisUtilities;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's

--- a/libraries/DSelector/DParticleCombo.cc
+++ b/libraries/DSelector/DParticleCombo.cc
@@ -29,7 +29,11 @@ DParticleCombo::DParticleCombo(DTreeInterface* locTreeInterface) : dTreeInterfac
 			//Create particle
 			DKinematicData* locKinematicData = NULL;
 			if(locPID == Unknown)
+			{
 				locKinematicData = NULL;
+				if(locParticleIndex >= 0)
+					locMissingIndices = pair<int, int>(locStepIndex, locParticleIndex);
+			}
 			else if(locParticleName == "ComboBeam")
 				locKinematicData = new DBeamParticle(dTreeInterface, locParticleName, locPID);
 			else if(locParticleName.substr(0, 6) == "Target")

--- a/libraries/DSelector/DParticleCombo.cc
+++ b/libraries/DSelector/DParticleCombo.cc
@@ -31,8 +31,7 @@ DParticleCombo::DParticleCombo(DTreeInterface* locTreeInterface) : dTreeInterfac
 			if(locPID == Unknown)
 			{
 				locKinematicData = NULL;
-				if(locParticleIndex >= 0)
-					locMissingIndices = pair<int, int>(locStepIndex, locParticleIndex);
+				locMissingIndices = pair<int, int>(locStepIndex, locParticleIndex);
 			}
 			else if(locParticleName == "ComboBeam")
 				locKinematicData = new DBeamParticle(dTreeInterface, locParticleName, locPID);


### PR DESCRIPTION
Also, add bonus histograms: When histogramming 1D masses, also histogram mass vs confidence level, to help determine cut values. 