### PR TITLE
Kinematic Cuts & RF Sidebands

### DIFF
--- a/libraries/DSelector/DAnalysisUtilities.cc
+++ b/libraries/DSelector/DAnalysisUtilities.cc
@@ -550,16 +550,27 @@ double DAnalysisUtilities::Get_BeamBunchPeriod(int locRunNumber) const
 	//get the first line
 	char buff[1024]; // I HATE char buffers
 	if(fgets(buff, sizeof(buff), locInputFile) == NULL)
+	{
+		gSystem->ClosePipe(locInputFile);
 		return -1.0;
+	}
+
+	//get the second line (where the # is)
+	if(fgets(buff, sizeof(buff), locInputFile) == NULL)
+	{
+		gSystem->ClosePipe(locInputFile);
+		return -1.0;
+	}
 	istringstream locStringStream(buff);
+
+	//extract it
+	double locBeamBunchPeriod = -1.0;
+	if(!(locStringStream >> locBeamBunchPeriod))
+		locBeamBunchPeriod = -1.0;
 
 	//Close the pipe
 	gSystem->ClosePipe(locInputFile);
 
-	//extract it
-	double locBeamBunchPeriod = 0.0;
-	if(!(locStringStream >> locBeamBunchPeriod))
-		return -1.0;
 	return locBeamBunchPeriod;
 }
 

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -316,15 +316,13 @@ class DCutAction_TrackShowerEOverP : public DAnalysisAction
 		double dShowerEOverPCut;
 };
 
-//kinematic cuts:
-//step index, PID, kinfit flag
-//p-range: min/max
-//theta-range: min/max
-//phi-range: min/max
-//to ignore: min > max
 class DCutAction_Kinematics : public DAnalysisAction
 {
-	//input range is what is cut
+	//input range is what is cut: cut is ignored if min > max
+	//if step index == -1: all steps
+	//if PID == Unknown: all particles
+	//particle must be detected
+	//angles in degrees
 	public:
 		DCutAction_Kinematics(const DParticleCombo* locParticleComboWrapper, int locStepIndex, Particle_t locPID, bool locUseKinFitFlag,
 			double locCutMinP, double locCutMaxP, double locCutMinTheta = 1.0, double locCutMaxTheta = 0.0, double locCutMinPhi = 1.0, double locCutMaxPhi = 0.0) :

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -316,4 +316,37 @@ class DCutAction_TrackShowerEOverP : public DAnalysisAction
 		double dShowerEOverPCut;
 };
 
+//kinematic cuts:
+//step index, PID, kinfit flag
+//p-range: min/max
+//theta-range: min/max
+//phi-range: min/max
+//to ignore: min > max
+class DCutAction_Kinematics : public DAnalysisAction
+{
+	//input range is what is cut
+	public:
+		DCutAction_Kinematics(const DParticleCombo* locParticleComboWrapper, int locStepIndex, Particle_t locPID, bool locUseKinFitFlag,
+			double locCutMinP, double locCutMaxP, double locCutMinTheta = 1.0, double locCutMaxTheta = 0.0, double locCutMinPhi = 1.0, double locCutMaxPhi = 0.0) :
+			DAnalysisAction(locParticleComboWrapper, "Cut_Kinematics", locUseKinFitFlag, ""),
+			dStepIndex(locStepIndex), dPID(locPID), dCutMinP(locCutMinP), dCutMaxP(locCutMaxP), dCutMinTheta(locCutMinTheta),
+			dCutMaxTheta(locCutMaxTheta), dCutMinPhi(locCutMinPhi), dCutMaxPhi(locCutMaxPhi) {}
+
+		string Get_ActionName(void) const;
+		void Initialize(void){};
+		void Reset_NewEvent(void){}
+		bool Perform_Action(void);
+
+	private:
+
+		int dStepIndex;
+		Particle_t dPID;
+		double dCutMinP;
+		double dCutMaxP;
+		double dCutMinTheta;
+		double dCutMaxTheta;
+		double dCutMinPhi;
+		double dCutMaxPhi;
+};
+
 #endif // _DCutActions_

--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -806,6 +806,25 @@ void DHistogramAction_MissingMass::Initialize(void)
 
 bool DHistogramAction_MissingMass::Perform_Action(void)
 {
+	//beam bunch check, if desired
+	if(dSidebandRange.first < dSidebandRange.second)
+	{
+		//get beam/rf delta-t
+		DKinematicData* locKinematicData = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
+		TLorentzVector locBeamX4 = dUseKinFitFlag ? locKinematicData->Get_X4() : locKinematicData->Get_X4_Measured();
+		double locRFTime = dUseKinFitFlag ? dParticleComboWrapper->Get_RFTime() : dParticleComboWrapper->Get_RFTime_Measured();
+		double locBeamRFDeltaT = locBeamX4.T() - (locRFTime + (locBeamX4.Z() - dTargetCenterZ)/29.9792458);
+
+		//get period, delta-t cut range
+		double locBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dParticleComboWrapper->Get_RunNumber());
+		double locMinDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.first - 1);
+		double locMaxDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.second + 1);
+
+		//check if outside of range
+		if((fabs(locBeamRFDeltaT) < locMinDeltaT) || (fabs(locBeamRFDeltaT) > locMaxDeltaT))
+			return true;
+	}
+
 	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
 
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
@@ -851,6 +870,8 @@ void DHistogramAction_MissingMassSquared::Initialize(void)
 	string locInitialParticlesROOTName = dParticleComboWrapper->Get_InitialParticlesROOTName();
 	string locFinalParticlesROOTName = dParticleComboWrapper->Get_DecayChainFinalParticlesROOTNames(0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, dUseKinFitFlag, true);
 
+	dTargetCenterZ = dParticleComboWrapper->Get_TargetCenter().Z();
+
 	// CREATE & GOTO MAIN FOLDER
 	CreateAndChangeTo_ActionDirectory();
 
@@ -891,6 +912,25 @@ void DHistogramAction_MissingMassSquared::Initialize(void)
 
 bool DHistogramAction_MissingMassSquared::Perform_Action(void)
 {
+	//beam bunch check, if desired
+	if(dSidebandRange.first < dSidebandRange.second)
+	{
+		//get beam/rf delta-t
+		DKinematicData* locKinematicData = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
+		TLorentzVector locBeamX4 = dUseKinFitFlag ? locKinematicData->Get_X4() : locKinematicData->Get_X4_Measured();
+		double locRFTime = dUseKinFitFlag ? dParticleComboWrapper->Get_RFTime() : dParticleComboWrapper->Get_RFTime_Measured();
+		double locBeamRFDeltaT = locBeamX4.T() - (locRFTime + (locBeamX4.Z() - dTargetCenterZ)/29.9792458);
+
+		//get period, delta-t cut range
+		double locBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dParticleComboWrapper->Get_RunNumber());
+		double locMinDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.first - 1);
+		double locMaxDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.second + 1);
+
+		//check if outside of range
+		if((fabs(locBeamRFDeltaT) < locMinDeltaT) || (fabs(locBeamRFDeltaT) > locMaxDeltaT))
+			return true;
+	}
+
 	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
 
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
@@ -990,6 +1030,25 @@ void DHistogramAction_MissingP4::Initialize(void)
 
 bool DHistogramAction_MissingP4::Perform_Action(void)
 {
+	//beam bunch check, if desired
+	if(dSidebandRange.first < dSidebandRange.second)
+	{
+		//get beam/rf delta-t
+		DKinematicData* locKinematicData = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
+		TLorentzVector locBeamX4 = dUseKinFitFlag ? locKinematicData->Get_X4() : locKinematicData->Get_X4_Measured();
+		double locRFTime = dUseKinFitFlag ? dParticleComboWrapper->Get_RFTime() : dParticleComboWrapper->Get_RFTime_Measured();
+		double locBeamRFDeltaT = locBeamX4.T() - (locRFTime + (locBeamX4.Z() - dTargetCenterZ)/29.9792458);
+
+		//get period, delta-t cut range
+		double locBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dParticleComboWrapper->Get_RunNumber());
+		double locMinDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.first - 1);
+		double locMaxDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.second + 1);
+
+		//check if outside of range
+		if((fabs(locBeamRFDeltaT) < locMinDeltaT) || (fabs(locBeamRFDeltaT) > locMaxDeltaT))
+			return true;
+	}
+
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
 	double locBeamEnergy = 0.0;
 	if(dUseKinFitFlag)

--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -766,6 +766,10 @@ void DHistogramAction_MissingMass::Initialize(void)
 	string locInitialParticlesROOTName = dParticleComboWrapper->Get_InitialParticlesROOTName();
 	string locFinalParticlesROOTName = dParticleComboWrapper->Get_DecayChainFinalParticlesROOTNames(0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, dUseKinFitFlag, true);
 
+	dTargetCenterZ = dParticleComboWrapper->Get_TargetCenter().Z();
+	dRunNumber = dParticleComboWrapper->Get_RunNumber();
+	dBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dRunNumber);
+
 	// CREATE & GOTO MAIN FOLDER
 	CreateAndChangeTo_ActionDirectory();
 
@@ -807,7 +811,7 @@ void DHistogramAction_MissingMass::Initialize(void)
 bool DHistogramAction_MissingMass::Perform_Action(void)
 {
 	//beam bunch check, if desired
-	if(dSidebandRange.first < dSidebandRange.second)
+	if(dBeamBunchRange.first <= dBeamBunchRange.second)
 	{
 		//get beam/rf delta-t
 		DKinematicData* locKinematicData = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
@@ -815,13 +819,14 @@ bool DHistogramAction_MissingMass::Perform_Action(void)
 		double locRFTime = dUseKinFitFlag ? dParticleComboWrapper->Get_RFTime() : dParticleComboWrapper->Get_RFTime_Measured();
 		double locBeamRFDeltaT = locBeamX4.T() - (locRFTime + (locBeamX4.Z() - dTargetCenterZ)/29.9792458);
 
-		//get period, delta-t cut range
-		double locBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dParticleComboWrapper->Get_RunNumber());
-		double locMinDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.first - 1);
-		double locMaxDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.second + 1);
+		//delta-t cut range
+		double locMinDeltaT = dBeamBunchPeriod*(double(dBeamBunchRange.first) - 0.5);
+		double locMaxDeltaT = dBeamBunchPeriod*(double(dBeamBunchRange.first) + 0.5);
 
 		//check if outside of range
 		if((fabs(locBeamRFDeltaT) < locMinDeltaT) || (fabs(locBeamRFDeltaT) > locMaxDeltaT))
+			return true;
+		if(std::isnan(locRFTime))
 			return true;
 	}
 
@@ -853,9 +858,9 @@ bool DHistogramAction_MissingMass::Perform_Action(void)
 			dHist_MissingMassVsBeamE->Fill(locBeamEnergy, locMissingP4.M());
 			dHist_MissingMassVsMissingP->Fill(locMissingP4.P(), locMissingP4.M());
 		}
-                if(dPreviouslyHistogrammed_ConLev.find(locSourceObjects_ConLev) == dPreviouslyHistogrammed_ConLev.end())
-                {
-                        dPreviouslyHistogrammed_ConLev.insert(locSourceObjects_ConLev);
+		if(dPreviouslyHistogrammed_ConLev.find(locSourceObjects_ConLev) == dPreviouslyHistogrammed_ConLev.end())
+		{
+			dPreviouslyHistogrammed_ConLev.insert(locSourceObjects_ConLev);
 			dHist_MissingMassVsConfidenceLevel->Fill(locConfidenceLevel, locMissingP4.M());
 			dHist_MissingMassVsConfidenceLevel_LogX->Fill(locConfidenceLevel, locMissingP4.M());
 		}
@@ -871,6 +876,8 @@ void DHistogramAction_MissingMassSquared::Initialize(void)
 	string locFinalParticlesROOTName = dParticleComboWrapper->Get_DecayChainFinalParticlesROOTNames(0, dMissingMassOffOfStepIndex, dMissingMassOffOfPIDs, dUseKinFitFlag, true);
 
 	dTargetCenterZ = dParticleComboWrapper->Get_TargetCenter().Z();
+	dRunNumber = dParticleComboWrapper->Get_RunNumber();
+	dBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dRunNumber);
 
 	// CREATE & GOTO MAIN FOLDER
 	CreateAndChangeTo_ActionDirectory();
@@ -913,7 +920,7 @@ void DHistogramAction_MissingMassSquared::Initialize(void)
 bool DHistogramAction_MissingMassSquared::Perform_Action(void)
 {
 	//beam bunch check, if desired
-	if(dSidebandRange.first < dSidebandRange.second)
+	if(dBeamBunchRange.first <= dBeamBunchRange.second)
 	{
 		//get beam/rf delta-t
 		DKinematicData* locKinematicData = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
@@ -921,13 +928,14 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(void)
 		double locRFTime = dUseKinFitFlag ? dParticleComboWrapper->Get_RFTime() : dParticleComboWrapper->Get_RFTime_Measured();
 		double locBeamRFDeltaT = locBeamX4.T() - (locRFTime + (locBeamX4.Z() - dTargetCenterZ)/29.9792458);
 
-		//get period, delta-t cut range
-		double locBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dParticleComboWrapper->Get_RunNumber());
-		double locMinDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.first - 1);
-		double locMaxDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.second + 1);
+		//delta-t cut range
+		double locMinDeltaT = dBeamBunchPeriod*(double(dBeamBunchRange.first) - 0.5);
+		double locMaxDeltaT = dBeamBunchPeriod*(double(dBeamBunchRange.first) + 0.5);
 
 		//check if outside of range
 		if((fabs(locBeamRFDeltaT) < locMinDeltaT) || (fabs(locBeamRFDeltaT) > locMaxDeltaT))
+			return true;
+		if(std::isnan(locRFTime))
 			return true;
 	}
 
@@ -976,6 +984,10 @@ void DHistogramAction_MissingP4::Initialize(void)
 	string locFinalParticlesROOTName = dParticleComboWrapper->Get_DecayChainFinalParticlesROOTNames(0, -1, deque<Particle_t>(), dUseKinFitFlag, !dUseKinFitFlag);
 	string locReactionString = locInitialParticlesROOTName + string("#rightarrow") + locFinalParticlesROOTName;
 	string locHistName, locHistTitle;
+
+	dTargetCenterZ = dParticleComboWrapper->Get_TargetCenter().Z();
+	dRunNumber = dParticleComboWrapper->Get_RunNumber();
+	dBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dRunNumber);
 
 	// CREATE & GOTO MAIN FOLDER
 	CreateAndChangeTo_ActionDirectory();
@@ -1031,7 +1043,7 @@ void DHistogramAction_MissingP4::Initialize(void)
 bool DHistogramAction_MissingP4::Perform_Action(void)
 {
 	//beam bunch check, if desired
-	if(dSidebandRange.first < dSidebandRange.second)
+	if(dBeamBunchRange.first <= dBeamBunchRange.second)
 	{
 		//get beam/rf delta-t
 		DKinematicData* locKinematicData = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
@@ -1039,13 +1051,14 @@ bool DHistogramAction_MissingP4::Perform_Action(void)
 		double locRFTime = dUseKinFitFlag ? dParticleComboWrapper->Get_RFTime() : dParticleComboWrapper->Get_RFTime_Measured();
 		double locBeamRFDeltaT = locBeamX4.T() - (locRFTime + (locBeamX4.Z() - dTargetCenterZ)/29.9792458);
 
-		//get period, delta-t cut range
-		double locBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dParticleComboWrapper->Get_RunNumber());
-		double locMinDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.first - 1);
-		double locMaxDeltaT = 0.5*locBeamBunchPeriod*double(dSidebandRange.second + 1);
+		//delta-t cut range
+		double locMinDeltaT = dBeamBunchPeriod*(double(dBeamBunchRange.first) - 0.5);
+		double locMaxDeltaT = dBeamBunchPeriod*(double(dBeamBunchRange.first) + 0.5);
 
 		//check if outside of range
 		if((fabs(locBeamRFDeltaT) < locMinDeltaT) || (fabs(locBeamRFDeltaT) > locMaxDeltaT))
+			return true;
+		if(std::isnan(locRFTime))
 			return true;
 	}
 

--- a/libraries/DSelector/DHistogramActions.h
+++ b/libraries/DSelector/DHistogramActions.h
@@ -239,7 +239,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0), dMissingMassOffOfPIDs(deque<Particle_t>()),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -259,20 +259,20 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(locMissingMassOffOfPIDs),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
 
 		DHistogramAction_MissingMass(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
 
-                void Reset_NewEvent(void) //reset uniqueness tracking
-                {
-                        dPreviouslyHistogrammed.clear();
-                        dPreviouslyHistogrammed_ConLev.clear();
-                }
+		void Reset_NewEvent(void) //reset uniqueness tracking
+		{
+			dPreviouslyHistogrammed.clear();
+			dPreviouslyHistogrammed_ConLev.clear();
+		}
 		void Initialize(void);
 		bool Perform_Action(void);
 
@@ -289,19 +289,23 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
 		int dConLevLowest10Power;
 
+		pair<int, int> dSidebandRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
+
 	private:
 		TH1I* dHist_MissingMass;
 		TH2I* dHist_MissingMassVsBeamE;
 		TH2I* dHist_MissingMassVsMissingP;
 		TH2I* dHist_MissingMassVsConfidenceLevel;
 		TH2I* dHist_MissingMassVsConfidenceLevel_LogX;
+
 		DAnalysisUtilities dAnalysisUtilities;
+		double dTargetCenterZ;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map
 		//Multiple combos: Contain maps within a set (easier, faster to search)
 		set<map<unsigned int, set<Int_t> > > dPreviouslyHistogrammed;
-                set<pair<Int_t, map<unsigned int, set<Int_t> > > > dPreviouslyHistogrammed_ConLev; //first Int_t: combo index: kinfit (probably) unique for each combo
+		set<pair<Int_t, map<unsigned int, set<Int_t> > > > dPreviouslyHistogrammed_ConLev; //first Int_t: combo index: kinfit (probably) unique for each combo
 };
 
 class DHistogramAction_MissingMassSquared : public DAnalysisAction
@@ -311,7 +315,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq), dMissingMassOffOfStepIndex(0), dMissingMassOffOfPIDs(deque<Particle_t>()),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -331,20 +335,20 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(locMissingMassOffOfPIDs),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
 
 		DHistogramAction_MissingMassSquared(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
 
-                void Reset_NewEvent(void) //reset uniqueness tracking
-                {
-                        dPreviouslyHistogrammed.clear();
-                        dPreviouslyHistogrammed_ConLev.clear();
-                }
+		void Reset_NewEvent(void) //reset uniqueness tracking
+		{
+			dPreviouslyHistogrammed.clear();
+			dPreviouslyHistogrammed_ConLev.clear();
+		}
 		void Initialize(void);
 		bool Perform_Action(void);
 
@@ -361,19 +365,23 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
 		int dConLevLowest10Power;
 
+		pair<int, int> dSidebandRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
+
 	private:
 		TH1I* dHist_MissingMass;
 		TH2I* dHist_MissingMassVsBeamE;
 		TH2I* dHist_MissingMassVsMissingP;
 		TH2I* dHist_MissingMassVsConfidenceLevel;
 		TH2I* dHist_MissingMassVsConfidenceLevel_LogX;
+
 		DAnalysisUtilities dAnalysisUtilities;
+		double dTargetCenterZ;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map
 		//Multiple combos: Contain maps within a set (easier, faster to search)
 		set<map<unsigned int, set<Int_t> > > dPreviouslyHistogrammed;
-                set<pair<Int_t, map<unsigned int, set<Int_t> > > > dPreviouslyHistogrammed_ConLev; //first Int_t: combo index: kinfit (probably) unique for each combo
+		set<pair<Int_t, map<unsigned int, set<Int_t> > > > dPreviouslyHistogrammed_ConLev; //first Int_t: combo index: kinfit (probably) unique for each combo
 };
 
 class DHistogramAction_MissingP4 : public DAnalysisAction
@@ -383,7 +391,8 @@ class DHistogramAction_MissingP4 : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingP4", locUseKinFitFlag, locActionUniqueString),
 			dNumMissingPxyBins(400), dNumMissingEPzBins(400), dNumMissingPtBins(400), dNum2DBeamEBins(600),
 			dNum2DMissingEPzBins(200), dNum2DMissingPtBins(200), dNum2DMissingPxyBins(200),
-			dMinMissingEPz(-0.1), dMaxMissingEPz(0.1), dMaxMissingPt(0.5), dMaxMissingPxy(0.1), dMinBeamE(0.0), dMaxBeamE(12.0) {}
+			dMinMissingEPz(-0.1), dMaxMissingEPz(0.1), dMaxMissingPt(0.5), dMaxMissingPxy(0.1), dMinBeamE(0.0), dMaxBeamE(12.0),
+			dSidebandRange(pair<int, int>(1, -1)) {}
 
 		void Reset_NewEvent(void){dPreviouslyHistogrammed.clear();}; //reset uniqueness tracking
 		void Initialize(void);
@@ -391,6 +400,8 @@ class DHistogramAction_MissingP4 : public DAnalysisAction
 
 		unsigned int dNumMissingPxyBins, dNumMissingEPzBins, dNumMissingPtBins, dNum2DBeamEBins, dNum2DMissingEPzBins, dNum2DMissingPtBins, dNum2DMissingPxyBins;
 		double dMinMissingEPz, dMaxMissingEPz, dMaxMissingPt, dMaxMissingPxy, dMinBeamE, dMaxBeamE;
+
+		pair<int, int> dSidebandRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
 
 	private:
 		TH1I* dHist_MissingE;
@@ -406,6 +417,7 @@ class DHistogramAction_MissingP4 : public DAnalysisAction
 		TH2I* dHist_MissingPyVsMissingPx;
 
 		DAnalysisUtilities dAnalysisUtilities;
+		double dTargetCenterZ;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map

--- a/libraries/DSelector/DHistogramActions.h
+++ b/libraries/DSelector/DHistogramActions.h
@@ -239,7 +239,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass), dMissingMassOffOfStepIndex(0), dMissingMassOffOfPIDs(deque<Particle_t>()),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dBeamBunchRange(pair<int, int>(1, -1)) {}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -259,19 +259,23 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(locMissingMassOffOfPIDs),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dBeamBunchRange(pair<int, int>(1, -1)) {}
 
 		DHistogramAction_MissingMass(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMass", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dBeamBunchRange(pair<int, int>(1, -1)) {}
 
-		void Reset_NewEvent(void) //reset uniqueness tracking
+		void Reset_NewEvent(void)
 		{
 			dPreviouslyHistogrammed.clear();
-			dPreviouslyHistogrammed_ConLev.clear();
+			if(dParticleComboWrapper->Get_RunNumber() != dRunNumber)
+			{
+				dRunNumber = dParticleComboWrapper->Get_RunNumber();
+				dBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dRunNumber);
+			}
 		}
 		void Initialize(void);
 		bool Perform_Action(void);
@@ -289,7 +293,7 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
 		int dConLevLowest10Power;
 
-		pair<int, int> dSidebandRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
+		pair<int, int> dBeamBunchRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
 
 	private:
 		TH1I* dHist_MissingMass;
@@ -300,6 +304,8 @@ class DHistogramAction_MissingMass : public DAnalysisAction
 
 		DAnalysisUtilities dAnalysisUtilities;
 		double dTargetCenterZ;
+		double dBeamBunchPeriod;
+		UInt_t dRunNumber;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map
@@ -315,7 +321,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq), dMissingMassOffOfStepIndex(0), dMissingMassOffOfPIDs(deque<Particle_t>()),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dBeamBunchRange(pair<int, int>(1, -1)) {}
 
 		//E.g. If:
 		//g, p -> K+, K+, Xi-
@@ -335,19 +341,23 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(locMissingMassOffOfPIDs),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dBeamBunchRange(pair<int, int>(1, -1)) {}
 
 		DHistogramAction_MissingMassSquared(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, int locMissingMassOffOfStepIndex, Particle_t locMissingMassOffOfPID, unsigned int locNumMassBins, double locMinMassSq, double locMaxMassSq, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Hist_MissingMassSquared", locUseKinFitFlag, locActionUniqueString),
 			dNumMassBins(locNumMassBins), dMinMass(locMinMassSq), dMaxMass(locMaxMassSq),
 			dMissingMassOffOfStepIndex(locMissingMassOffOfStepIndex), dMissingMassOffOfPIDs(deque<Particle_t>(1, locMissingMassOffOfPID)),
 			dNum2DMassBins(locNumMassBins/2), dNum2DBeamEBins(600), dNum2DMissPBins(450), dMinBeamE(0.0), dMaxBeamE(12.0), dMinMissP(0.0), dMaxMissP(9.0),
-			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dSidebandRange(pair<int, int>(1, -1)) {}
+			dNumConLevBins(1000), dNumBinsPerConLevPower(18), dConLevLowest10Power(-50), dBeamBunchRange(pair<int, int>(1, -1)) {}
 
-		void Reset_NewEvent(void) //reset uniqueness tracking
+		void Reset_NewEvent(void)
 		{
 			dPreviouslyHistogrammed.clear();
-			dPreviouslyHistogrammed_ConLev.clear();
+			if(dParticleComboWrapper->Get_RunNumber() != dRunNumber)
+			{
+				dRunNumber = dParticleComboWrapper->Get_RunNumber();
+				dBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dRunNumber);
+			}
 		}
 		void Initialize(void);
 		bool Perform_Action(void);
@@ -365,7 +375,7 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 		unsigned int dNumConLevBins, dNumBinsPerConLevPower;
 		int dConLevLowest10Power;
 
-		pair<int, int> dSidebandRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
+		pair<int, int> dBeamBunchRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
 
 	private:
 		TH1I* dHist_MissingMass;
@@ -376,6 +386,8 @@ class DHistogramAction_MissingMassSquared : public DAnalysisAction
 
 		DAnalysisUtilities dAnalysisUtilities;
 		double dTargetCenterZ;
+		double dBeamBunchPeriod;
+		UInt_t dRunNumber;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map
@@ -392,16 +404,24 @@ class DHistogramAction_MissingP4 : public DAnalysisAction
 			dNumMissingPxyBins(400), dNumMissingEPzBins(400), dNumMissingPtBins(400), dNum2DBeamEBins(600),
 			dNum2DMissingEPzBins(200), dNum2DMissingPtBins(200), dNum2DMissingPxyBins(200),
 			dMinMissingEPz(-0.1), dMaxMissingEPz(0.1), dMaxMissingPt(0.5), dMaxMissingPxy(0.1), dMinBeamE(0.0), dMaxBeamE(12.0),
-			dSidebandRange(pair<int, int>(1, -1)) {}
+			dBeamBunchRange(pair<int, int>(1, -1)) {}
 
-		void Reset_NewEvent(void){dPreviouslyHistogrammed.clear();}; //reset uniqueness tracking
+		void Reset_NewEvent(void)
+		{
+			dPreviouslyHistogrammed.clear();
+			if(dParticleComboWrapper->Get_RunNumber() != dRunNumber)
+			{
+				dRunNumber = dParticleComboWrapper->Get_RunNumber();
+				dBeamBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(dRunNumber);
+			}
+		}
 		void Initialize(void);
 		bool Perform_Action(void);
 
 		unsigned int dNumMissingPxyBins, dNumMissingEPzBins, dNumMissingPtBins, dNum2DBeamEBins, dNum2DMissingEPzBins, dNum2DMissingPtBins, dNum2DMissingPxyBins;
 		double dMinMissingEPz, dMaxMissingEPz, dMaxMissingPt, dMaxMissingPxy, dMinBeamE, dMaxBeamE;
 
-		pair<int, int> dSidebandRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
+		pair<int, int> dBeamBunchRange; //min/max #peaks range: if 2, 4: fills for sidebands -4, -3, -2, 2, 3, 4 //for main peak: 0, 0 //for all: set min > max
 
 	private:
 		TH1I* dHist_MissingE;
@@ -418,6 +438,8 @@ class DHistogramAction_MissingP4 : public DAnalysisAction
 
 		DAnalysisUtilities dAnalysisUtilities;
 		double dTargetCenterZ;
+		double dBeamBunchPeriod;
+		UInt_t dRunNumber;
 
 		//In general: Could have multiple particles with the same PID: Use a set of Int_t's
 		//In general: Multiple PIDs, so multiple sets: Contain within a map

--- a/libraries/DSelector/DParticleCombo.cc
+++ b/libraries/DSelector/DParticleCombo.cc
@@ -99,6 +99,7 @@ DParticleCombo::DParticleCombo(DTreeInterface* locTreeInterface) : dTreeInterfac
 
 	Setup_Branches();
 	Setup_X4Branches();
+	Setup_EventBranches();
 	Setup_KinFitConstraintInfo();
 
 	Print_Reaction();
@@ -230,6 +231,51 @@ void DParticleCombo::Setup_X4Branches(void)
 	}
 }
 
+void DParticleCombo::Setup_EventBranches(void)
+{
+	// EVENT DATA
+	dRunNumber = (UInt_t*)dTreeInterface->Get_Branch("RunNumber")->GetAddress();
+	dEventNumber = (ULong64_t*)dTreeInterface->Get_Branch("EventNumber")->GetAddress();
+	TBranch* locL1TriggerBitsBranch = dTreeInterface->Get_Branch("L1TriggerBits");
+	dL1TriggerBits = (locL1TriggerBitsBranch != NULL) ? (UInt_t*)locL1TriggerBitsBranch->GetAddress() : NULL;
+
+	// MC-ONLY
+	bool locIsMCFlag = (dTreeInterface->Get_Branch("MCWeight") != NULL);
+	if(locIsMCFlag)
+	{
+		dMCWeight = (Float_t*)dTreeInterface->Get_Branch("MCWeight")->GetAddress();
+		dIsThrownTopology = (Bool_t*)dTreeInterface->Get_Branch("IsThrownTopology")->GetAddress();
+	}
+}
+
+void DParticleCombo::Setup_KinFitConstraintInfo(void)
+{
+	TMap* locMiscInfoMap = (TMap*)dTreeInterface->Get_UserInfo()->FindObject("MiscInfoMap");
+	if(locMiscInfoMap->FindObject("KinFitConstraints") == NULL)
+	{
+		dKinFitConstraints = "NA";
+		dNumKinFitConstraints = 0;
+		dNumKinFitUnknowns = 0;
+		return;
+	}
+
+	//constraint string
+	TObjString* locObjString = (TObjString*)locMiscInfoMap->GetValue("KinFitConstraints");
+	dKinFitConstraints = locObjString->GetName();
+
+	//# constraints
+	locObjString = (TObjString*)locMiscInfoMap->GetValue("NumKinFitConstraints");
+	istringstream locConstraintStream;
+	locConstraintStream.str(locObjString->GetName());
+	locConstraintStream >> dNumKinFitConstraints;
+
+	//# unknowns
+	locObjString = (TObjString*)locMiscInfoMap->GetValue("NumKinFitUnknowns");
+	istringstream locUnknownStream;
+	locUnknownStream.str(locObjString->GetName());
+	locUnknownStream >> dNumKinFitUnknowns;
+}
+
 /***************************************************************** UTILITY FUNCTIONS ******************************************************************/
 
 string DParticleCombo::Get_DecayChainFinalParticlesROOTNames(size_t locStepIndex, int locUpToStepIndex, deque<Particle_t> locUpThroughPIDs, bool locKinFitResultsFlag, bool locExpandDecayingParticlesFlag) const
@@ -280,32 +326,4 @@ string DParticleCombo::Get_DecayChainFinalParticlesROOTNames(size_t locStepIndex
 			locName += Get_DecayChainFinalParticlesROOTNames(locDecayingStepIndex, locUpToStepIndex, locUpThroughPIDs, locKinFitResultsFlag, locExpandDecayingParticlesFlag);
 	}
 	return locName;
-}
-
-void DParticleCombo::Setup_KinFitConstraintInfo(void)
-{
-	TMap* locMiscInfoMap = (TMap*)dTreeInterface->Get_UserInfo()->FindObject("MiscInfoMap");
-	if(locMiscInfoMap->FindObject("KinFitConstraints") == NULL)
-	{
-		dKinFitConstraints = "NA";
-		dNumKinFitConstraints = 0;
-		dNumKinFitUnknowns = 0;
-		return;
-	}
-
-	//constraint string
-	TObjString* locObjString = (TObjString*)locMiscInfoMap->GetValue("KinFitConstraints");
-	dKinFitConstraints = locObjString->GetName();
-
-	//# constraints
-	locObjString = (TObjString*)locMiscInfoMap->GetValue("NumKinFitConstraints");
-	istringstream locConstraintStream;
-	locConstraintStream.str(locObjString->GetName());
-	locConstraintStream >> dNumKinFitConstraints;
-
-	//# unknowns
-	locObjString = (TObjString*)locMiscInfoMap->GetValue("NumKinFitUnknowns");
-	istringstream locUnknownStream;
-	locUnknownStream.str(locObjString->GetName());
-	locUnknownStream >> dNumKinFitUnknowns;
 }

--- a/libraries/DSelector/DParticleCombo.h
+++ b/libraries/DSelector/DParticleCombo.h
@@ -66,6 +66,13 @@ class DParticleCombo
 		UInt_t Get_NDF_KinFit(void) const;
 		Float_t Get_ConfidenceLevel_KinFit(void) const;
 
+		// EVENT INFO: //Doesn't really belong in DParticleCombo, but much easier to pass into actions this way
+		UInt_t Get_RunNumber(void) const;
+		ULong64_t Get_EventNumber(void) const;
+		UInt_t Get_L1TriggerBits(void) const;
+		Bool_t Get_IsThrownTopology(void) const;
+		Float_t Get_MCWeight(void) const;
+
 		//GET CUSTOM DATA
 		template <typename DType> DType Get_Fundamental(string locBranchName) const;
 		template <typename DType> DType Get_TObject(string locBranchName) const;
@@ -88,6 +95,7 @@ class DParticleCombo
 		int Get_DecayStepIndex(int locStepIndex, int locParticleIndex) const;
 		pair<int, int> Get_DecayFromIndices(int locStepIndex) const;
 		void Setup_X4Branches(void);
+		void Setup_EventBranches(void);
 		void Setup_KinFitConstraintInfo(void);
 
 		//RE-INITIALIZE (e.g. with the next TTree in a chain)
@@ -121,6 +129,13 @@ class DParticleCombo
 		string dKinFitConstraints;
 		size_t dNumKinFitConstraints;
 		size_t dNumKinFitUnknowns;
+
+		// EVENT DATA
+		UInt_t* dRunNumber;
+		ULong64_t* dEventNumber;
+		UInt_t* dL1TriggerBits;
+		Float_t* dMCWeight; //only present if simulated data
+		Bool_t* dIsThrownTopology; //only present if simulated data
 };
 
 inline void DParticleCombo::Print_Reaction(void) const
@@ -260,6 +275,32 @@ inline DParticleComboStep* DParticleCombo::Get_MissingParticleStep(void) const
 			return dParticleComboSteps[loc_i];
 	}
 	return NULL;
+}
+
+// EVENT DATA
+inline UInt_t DParticleCombo::Get_RunNumber(void) const
+{
+	return *dRunNumber;
+}
+
+inline ULong64_t DParticleCombo::Get_EventNumber(void) const
+{
+	return *dEventNumber;
+}
+
+inline UInt_t DParticleCombo::Get_L1TriggerBits(void) const
+{
+	return *dL1TriggerBits;
+}
+
+inline Bool_t DParticleCombo::Get_IsThrownTopology(void) const
+{
+	return ((dIsThrownTopology != NULL) ? *dIsThrownTopology : false);
+}
+
+inline Float_t DParticleCombo::Get_MCWeight(void) const
+{
+	return ((dMCWeight != NULL) ? *dMCWeight : 0.0);
 }
 
 //GET CUSTOM DATA


### PR DESCRIPTION
Add new action for applying cuts on particle kinematics. 

In missing mass/p4 hist actions, add ability to select range of beam/rf delta-t peaks to use (default is still all). 