### PR TITLE
Instead of passing arround TClonesArray*, use TClonesArray**.

### DIFF
--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -250,6 +250,7 @@ bool DHistogramAction_ParticleComboKinematics::Perform_Action(void)
 		//final particles
 		for(size_t loc_j = 0; loc_j < locParticleComboStepWrapper->Get_NumFinalParticles(); ++loc_j)
 		{
+			cout << "j = " << loc_j << endl;
 			DKinematicData* locKinematicData = locParticleComboStepWrapper->Get_FinalParticle(loc_j);
 			if(locKinematicData == NULL)
 				continue; //e.g. a decaying or missing particle whose params aren't set yet

--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -250,7 +250,6 @@ bool DHistogramAction_ParticleComboKinematics::Perform_Action(void)
 		//final particles
 		for(size_t loc_j = 0; loc_j < locParticleComboStepWrapper->Get_NumFinalParticles(); ++loc_j)
 		{
-			cout << "j = " << loc_j << endl;
 			DKinematicData* locKinematicData = locParticleComboStepWrapper->Get_FinalParticle(loc_j);
 			if(locKinematicData == NULL)
 				continue; //e.g. a decaying or missing particle whose params aren't set yet

--- a/libraries/DSelector/DKinematicData.cc
+++ b/libraries/DSelector/DKinematicData.cc
@@ -42,11 +42,11 @@ void DKinematicData::Setup_Branches(void)
 	{
 		//P4_Measured
 		locBranchName = dBranchNamePrefix + string("__P4");
-		dP4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dP4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//X4_Measured
 		locBranchName = dBranchNamePrefix + string("__X4");
-		dX4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//ARRAY SIZE
 		dArraySize = (UInt_t*)dTreeInterface->Get_Branch("NumThrown")->GetAddress();
@@ -59,11 +59,11 @@ void DKinematicData::Setup_Branches(void)
 	{
 		//P4_Measured
 		locBranchName = dBranchNamePrefix + string("__P4_Measured");
-		dP4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dP4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//X4_Measured
 		locBranchName = dBranchNamePrefix + string("__X4_Measured");
-		dX4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//ARRAY SIZE
 		if(dBranchNamePrefix == "Beam")
@@ -82,14 +82,14 @@ void DKinematicData::Setup_Branches(void)
 	//Now, is combo particle
 	//P4_KinFit
 	locBranchName = dBranchNamePrefix + string("__P4_KinFit");
-	dP4_KinFit = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+	dP4_KinFit = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 	//X4_KinFit
 	if(dBranchNamePrefix.substr(0, 8) == "Decaying")
 		locBranchName = dBranchNamePrefix + string("__X4");
 	else
 		locBranchName = dBranchNamePrefix + string("__X4_KinFit");
-	dX4_KinFit = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+	dX4_KinFit = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 	//if decaying/missing, return
 	if((dBranchNamePrefix.substr(0, 8) == "Decaying") || (dBranchNamePrefix.substr(0, 7) == "Missing"))
@@ -109,11 +109,11 @@ void DKinematicData::Setup_Branches(void)
 
 		//X4_Measured
 		locBranchName = "Beam__X4_Measured";
-		dX4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//X4_KinFit
 		locBranchName = "ComboBeam__X4_KinFit";
-		dX4_KinFit = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_KinFit = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 	}
 	else if(dBranchNamePrefix == "ComboBeam") //beam
 	{
@@ -126,11 +126,11 @@ void DKinematicData::Setup_Branches(void)
 
 		//P4_Measured
 		locBranchName = dMeasuredBranchNamePrefix + string("__P4_Measured");
-		dP4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dP4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//X4_Measured
 		locBranchName = dMeasuredBranchNamePrefix + string("__X4_Measured");
-		dX4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 	}
 	else if(ParticleCharge(dPID) == 0) //neutral: get from combo object
 	{
@@ -143,11 +143,11 @@ void DKinematicData::Setup_Branches(void)
 
 		//P4_Measured
 		locBranchName = dBranchNamePrefix + string("__P4_Measured");
-		dP4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dP4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//X4_Measured
 		locBranchName = dBranchNamePrefix + string("__X4_Measured");
-		dX4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 	}
 	else //charged: get from measured object
 	{
@@ -160,10 +160,10 @@ void DKinematicData::Setup_Branches(void)
 
 		//P4_Measured
 		locBranchName = dMeasuredBranchNamePrefix + string("__P4_Measured");
-		dP4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dP4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 		//X4_Measured
 		locBranchName = dMeasuredBranchNamePrefix + string("__X4_Measured");
-		dX4_Measured = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+		dX4_Measured = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 	}
 }

--- a/libraries/DSelector/DKinematicData.h
+++ b/libraries/DSelector/DKinematicData.h
@@ -97,14 +97,14 @@ class DKinematicData
 		TBranch* dBranch_PID;
 
 		// P4
-		TClonesArray* dP4_KinFit; //NULL if not kinfit
-		TClonesArray* dP4_Measured; //NULL if target, missing, decaying, or thrown beam
+		TClonesArray** dP4_KinFit; //NULL if not kinfit
+		TClonesArray** dP4_Measured; //NULL if target, missing, decaying, or thrown beam
 		TLorentzVector dFixedP4; //use if target
 		TLorentzVector* dThrownBeamP4; //NULL if not thrown beam
 
 		// X4
-		TClonesArray* dX4_KinFit; //NULL if not kinfit
-		TClonesArray* dX4_Measured; //NULL if thrown beam //if missing, decaying, or target: is from a different particle
+		TClonesArray** dX4_KinFit; //NULL if not kinfit
+		TClonesArray** dX4_Measured; //NULL if thrown beam //if missing, decaying, or target: is from a different particle
 		TLorentzVector* dThrownBeamX4; //NULL if not thrown beam
 };
 
@@ -173,13 +173,13 @@ inline TLorentzVector DKinematicData::Get_P4_Measured(void) const
 		return *dThrownBeamP4; //thrown beam
 
 	int locArrayIndex = Get_IsDetectedComboNeutralParticle() ? dArrayIndex : dMeasuredArrayIndex;
-	return *((TLorentzVector*)dP4_Measured->At(locArrayIndex));
+	return *((TLorentzVector*)(*dP4_Measured)->At(locArrayIndex));
 }
 
 inline TLorentzVector DKinematicData::Get_P4(void) const
 {
 	if(dP4_KinFit != NULL)
-		return *((TLorentzVector*)dP4_KinFit->At(dArrayIndex));
+		return *((TLorentzVector*)(*dP4_KinFit)->At(dArrayIndex));
 	return Get_P4_Measured();
 }
 
@@ -189,13 +189,13 @@ inline TLorentzVector DKinematicData::Get_X4_Measured(void) const
 		return *dThrownBeamX4; //thrown beam
 
 	int locArrayIndex = Get_IsDetectedComboNeutralParticle() ? dArrayIndex : dMeasuredArrayIndex;
-	return *((TLorentzVector*)dX4_Measured->At(locArrayIndex));
+	return *((TLorentzVector*)(*dX4_Measured)->At(locArrayIndex));
 }
 
 inline TLorentzVector DKinematicData::Get_X4(void) const
 {
 	if(dX4_KinFit != NULL)
-		return *((TLorentzVector*)dX4_KinFit->At(dArrayIndex));
+		return *((TLorentzVector*)(*dX4_KinFit)->At(dArrayIndex));
 	return Get_X4_Measured();
 }
 

--- a/libraries/DSelector/DNeutralParticleHypothesis.h
+++ b/libraries/DSelector/DNeutralParticleHypothesis.h
@@ -88,7 +88,7 @@ class DNeutralParticleHypothesis : public DKinematicData
 		TBranch* dBranch_Energy_BCAL;
 		TBranch* dBranch_Energy_BCALPreshower;
 		TBranch* dBranch_Energy_FCAL;
-		TClonesArray* dX4_Shower;
+		TClonesArray** dX4_Shower;
 
 		//TRACK MATCHING
 		TBranch* dBranch_TrackBCAL_DeltaPhi;
@@ -150,7 +150,7 @@ inline void DNeutralParticleHypothesis::Setup_Branches(void)
 	dBranch_Energy_FCAL = dTreeInterface->Get_Branch(locBranchName);
 
 	locBranchName = "NeutralHypo__X4_Shower";
-	dX4_Shower = dTreeInterface->Get_Pointer_TClonesArray(locBranchName);
+	dX4_Shower = dTreeInterface->Get_PointerToPointerTo_TClonesArray(locBranchName);
 
 	//TRACK MATCHING:
 	locBranchName = "NeutralHypo__TrackBCAL_DeltaPhi";
@@ -268,7 +268,7 @@ inline Float_t DNeutralParticleHypothesis::Get_Energy_FCAL(void) const
 
 inline TLorentzVector DNeutralParticleHypothesis::Get_X4_Shower(void) const
 {
-	return *((TLorentzVector*)dX4_Shower->At(dMeasuredArrayIndex));
+	return *((TLorentzVector*)(*dX4_Shower)->At(dMeasuredArrayIndex));
 }
 
 //TRACK MATCHING:

--- a/libraries/DSelector/DParticleCombo.cc
+++ b/libraries/DSelector/DParticleCombo.cc
@@ -63,6 +63,7 @@ DParticleCombo::DParticleCombo(DTreeInterface* locTreeInterface) : dTreeInterfac
 				locKinematicData = new DChargedTrackHypothesis(dTreeInterface, locParticleName, locPID);
 			else
 				locKinematicData = new DNeutralParticleHypothesis(dTreeInterface, locParticleName, locPID);
+
 			locParticleMap[locStepIndex][locParticleIndex] = pair<Particle_t, DKinematicData*>(locPID, locKinematicData);
 		}
 	}
@@ -103,6 +104,8 @@ DParticleCombo::DParticleCombo(DTreeInterface* locTreeInterface) : dTreeInterfac
 	Setup_KinFitConstraintInfo();
 
 	Print_Reaction();
+
+	Get_ParticleComboStep(0)->Get_InitialParticle()->Get_X4();
 }
 
 /****************************************************************** SETUP FUNCTIONS *******************************************************************/
@@ -181,7 +184,7 @@ void DParticleCombo::Setup_X4Branches(void)
 	//Set X4 for decaying particles & steps
 	for(size_t loc_i = 0; loc_i < dParticleComboSteps.size(); ++loc_i)
 	{
-		TClonesArray* locX4Step = NULL;
+		TClonesArray** locX4Step = NULL;
 		TBranch* locBranch_X4MeasuredIndex = NULL;
 
 		//First check if in tree

--- a/libraries/DSelector/DParticleComboStep.h
+++ b/libraries/DSelector/DParticleComboStep.h
@@ -94,7 +94,7 @@ class DParticleComboStep
 		int dMissingParticleIndex; //-2 if none, -1 if parent, > 0 if final state
 
 		// SPACETIME VERTEX
-		TClonesArray* dX4_Step;
+		TClonesArray** dX4_Step;
 		TBranch* dBranch_X4MeasuredIndex; //branch index for dX4_Step if retrieved from a measured source //if kinfit, is just combo index
 };
 
@@ -175,7 +175,7 @@ inline void DParticleComboStep::Print_Reaction(void) const
 inline TLorentzVector DParticleComboStep::Get_X4(void) const
 {
 	UInt_t locArrayIndex = (dBranch_X4MeasuredIndex == NULL) ? dComboIndex : ((UInt_t*)dBranch_X4MeasuredIndex->GetAddress())[dComboIndex];
-	return *((TLorentzVector*)dX4_Step->At(locArrayIndex));
+	return *((TLorentzVector*)(*dX4_Step)->At(locArrayIndex));
 }
 
 inline DKinematicData* DParticleComboStep::Get_MissingParticle(void) const

--- a/libraries/DSelector/DTreeInterface.h
+++ b/libraries/DSelector/DTreeInterface.h
@@ -89,7 +89,7 @@ class DTreeInterface
 		//GET OBJECT POINTERS
 		template <typename DType> DType* Get_Pointer_Fundamental(string locBranchName) const;
 		template <typename DType> DType* Get_Pointer_TObject(string locBranchName) const;
-		TClonesArray* Get_Pointer_TClonesArray(string locBranchName);
+		TClonesArray** Get_PointerToPointerTo_TClonesArray(string locBranchName); //ROOT sometimes changes the pointer!
 
 		//GET OBJECTS
 		template <typename DType> DType Get_Fundamental(string locBranchName) const;
@@ -361,13 +361,13 @@ template <typename DType> inline DType* DTreeInterface::Get_Pointer_TObject(stri
 	return ((locBranch != NULL) ? *(DType**)locBranch->GetAddress() : NULL);
 }
 
-inline TClonesArray* DTreeInterface::Get_Pointer_TClonesArray(string locBranchName)
+inline TClonesArray** DTreeInterface::Get_PointerToPointerTo_TClonesArray(string locBranchName)
 {
 	TBranch* locBranch = Get_Branch(locBranchName);
 	if(locBranch == NULL)
 		return NULL;
 
-	return *(TClonesArray**)locBranch->GetAddress();
+	return (TClonesArray**)locBranch->GetAddress();
 }
 
 //GET OBJECTS
@@ -388,7 +388,7 @@ template <typename DType> inline DType DTreeInterface::Get_TObject(string locBra
 
 template <typename DType> inline DType DTreeInterface::Get_TObject(string locBranchName, UInt_t locArrayIndex)
 {
-	return *((DType*)Get_Pointer_TClonesArray(locBranchName)->At(locArrayIndex));
+	return *((DType*)(*Get_PointerToPointerTo_TClonesArray(locBranchName))->At(locArrayIndex));
 }
 
 //INCREASE ARRAY SIZE //For when reading only! Not when writing
@@ -548,7 +548,7 @@ template <typename DType> inline void DTreeInterface::Fill_Fundamental(string lo
 
 template <typename DType> inline void DTreeInterface::Fill_TObject(string locBranchName, const DType& locObject, unsigned int locArrayIndex)
 {
-	TClonesArray* locClonesArray = Get_Pointer_TClonesArray(locBranchName);
+	TClonesArray* locClonesArray = *Get_PointerToPointerTo_TClonesArray(locBranchName);
 	if(locArrayIndex == 0) //ASSUMES FILLED IN ORDER!!!
 		locClonesArray->Clear(); //empties array
 	*(DType*)locClonesArray->ConstructedAt(locArrayIndex) = locObject;


### PR DESCRIPTION
This is because ROOT is allowed-to (and sometimes does), change the pointer to the clones array.  However, it cannot change the **.