### PR TITLE
Fix bug when increasing the size of the fundamental arrays.

### DIFF
--- a/libraries/DSelector/DSelector.cc
+++ b/libraries/DSelector/DSelector.cc
@@ -9,6 +9,7 @@ void DSelector::Init(TTree *locTree)
 	// Init() will be called many times when running on PROOF (once per file to be processed).
 
 	// GET OPTION
+	cout << "INITIALIZE NEW TREE" << endl;
 	dOption = GetOption(); //optional argument given to TTree::Process()
 	if(fInput != NULL) 
 		dOption = ((TNamed*)fInput->FindObject("OPTIONS"))->GetTitle();
@@ -27,8 +28,7 @@ void DSelector::Init(TTree *locTree)
 		dTreeInterface->Set_NewTree(locTree);
 
 	// SETUP BRANCHES
-	if(!dInitializedFlag)
-		Setup_Branches();
+	Setup_Branches();
 
 	// IF PREVIOUSLY INITIALIZED, RE-INIT WRAPPERS
 	if(dInitializedFlag)

--- a/libraries/DSelector/DTreeInterface.cc
+++ b/libraries/DSelector/DTreeInterface.cc
@@ -187,6 +187,7 @@ void DTreeInterface::Get_Entry(Long64_t locEntry)
 		//get the new array size
 		Get_Branch(locArraySizeBranchName)->GetEntry(locEntry);
 		UInt_t locNewArraySize = Get_Fundamental<UInt_t>(locArraySizeBranchName);
+//cout << "branch name, current array size, new array size = " << locArraySizeBranchName << ", " << locCurrentArraySize << ", " << locNewArraySize << endl;
 
 		//compare them
 		if(locNewArraySize <= locCurrentArraySize)

--- a/libraries/DSelector/DTreeInterface.h
+++ b/libraries/DSelector/DTreeInterface.h
@@ -397,7 +397,11 @@ template <typename DType> inline void DTreeInterface::Increase_ArraySize(string 
 	//create a new, larger array if the current one is too small
 		//DOES NOT copy the old results!  In other words, only call BETWEEN entries, not DURING an entry
 	DType* locOldBranchAddress = Get_Pointer_Fundamental<DType>(locBranchName);
-	dInputTree->SetBranchAddress(locBranchName.c_str(), new DType[locNewArraySize]);
+
+	dMemoryMap_Fundamental[locBranchName] = static_cast<void*>(new DType[locNewArraySize]);
+	Get_Branch(locBranchName)->SetAddress(dMemoryMap_Fundamental[locBranchName]);
+
+	dFundamentalArraySizeMap[locBranchName] = locNewArraySize;
 	delete[] locOldBranchAddress;
 }
 
@@ -531,7 +535,9 @@ template <typename DType> inline void DTreeInterface::Fill_Fundamental(string lo
 	if(locArrayIndex >= locCurrentArraySize)
 	{
 		DType* locOldArray = locArray;
-		dOutputTree->SetBranchAddress(locBranchName.c_str(), new DType[locArrayIndex + 100]);
+		unsigned int locNewArraySize = locArrayIndex + 100;
+		dMemoryMap_Fundamental[locBranchName] = static_cast<void*>(new DType[locNewArraySize]);
+		dOutputTree->SetBranchAddress(locBranchName.c_str(), dMemoryMap_Fundamental[locBranchName]);
 		locArray = Get_Pointer_Fundamental<DType>(locBranchName);
 
 		//copy the old contents into the new array
@@ -539,7 +545,7 @@ template <typename DType> inline void DTreeInterface::Fill_Fundamental(string lo
 			locArray[loc_i] = locOldArray[loc_i];
 
 		delete[] locOldArray;
-		dFundamentalArraySizeMap[locBranchName] = locArrayIndex + 1;
+		dFundamentalArraySizeMap[locBranchName] = locNewArraySize;
 	}
 
 	//set the data


### PR DESCRIPTION
This caused crashes when:

1) The array size needed to be increased (e.g. > 100 combos in an event).  
And
2) There are multiple files being analyzed. 