### PR TITLE
#Added Get_CoherentPeak()

### DIFF
--- a/libraries/DSelector/DAnalysisUtilities.cc
+++ b/libraries/DSelector/DAnalysisUtilities.cc
@@ -569,6 +569,43 @@ bool DAnalysisUtilities::Get_PolarizationAngle(int locRunNumber, int& locPolariz
 	
 	return true;
 }
+bool DAnalysisUtilities::Get_CoherentPeak(int locRunNumber, double& locCoherentPeak, bool locIsPolarizedFlag) const
+{
+	//RCDB environment must be setup!!
+
+	// amorphous runs can have any value
+	if (!locIsPolarizedFlag)
+	{
+	  locCoherentPeak = 0.0;
+	  return false;
+	}
+
+	//Pipe the current constant into this function
+	ostringstream locCommandStream;
+	locCommandStream << "rcnd " << locRunNumber << " coherent_peak";
+	FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
+	if(locInputFile == NULL)
+		return false;
+
+	//get the first line
+	char buff[1024];
+	if(fgets(buff, sizeof(buff), locInputFile) == NULL)
+		return 0;
+	istringstream locStringStream(buff);
+
+	//Close the pipe
+	gSystem->ClosePipe(locInputFile);
+
+	//extract it
+	string locCoherentPeakString;
+	if(!(locStringStream >> locCoherentPeakString))
+		return false;
+
+	// convert string to double
+	locCoherentPeak = atof(locCoherentPeakString.c_str());
+	
+	return true;
+}
 
 double DAnalysisUtilities::Get_BeamBunchPeriod(int locRunNumber) const
 {

--- a/libraries/DSelector/DAnalysisUtilities.h
+++ b/libraries/DSelector/DAnalysisUtilities.h
@@ -25,6 +25,7 @@ class DAnalysisUtilities
 
 		bool Get_IsPolarizedBeam(int locRunNumber, bool& locIsPARAFlag) const; //RCDB environment must be setup!!
 		bool Get_PolarizationAngle(int locRunNumber, int& locPolarizationAngle) const; //RCDB environment must be setup!!
+		bool Get_CoherentPeak(int locRunNumber, double& locCoherentPeak, bool locIsPolarizedFlag) const; //RCDB environment must be setup!!
 		double Get_BeamBunchPeriod(int locRunNumber) const; //CCDB environment must be setup!!
 
 		double Calc_ProdPlanePhi_Pseudoscalar(double locBeamEnergy, Particle_t locTargetPID, const TLorentzVector& locMesonP4) const;


### PR DESCRIPTION
Uses RCDB to get 'coherent_peak'. Can be used to adjust beam energy cuts based on where the coherent peak is.