### PR TITLE
NumUnusedTracks

### DIFF
--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -569,3 +569,15 @@ bool DCutAction_Energy_UnusedShowers::Perform_Action(void)
 {
 	return (dParticleComboWrapper->Get_Energy_UnusedShowers() <= dMaxEnergy_UnusedShowersCut);
 }
+
+string DCutAction_NumUnusedTracks::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dMaxUnusedTracks;
+	return locStream.str();
+}
+
+bool DCutAction_NumUnusedTracks::Perform_Action(void)
+{
+	return (dParticleComboWrapper->Get_NumUnusedTracks() <= dMaxUnusedTracks);
+}

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -405,5 +405,22 @@ class DCutAction_Energy_UnusedShowers : public DAnalysisAction
                 double dMaxEnergy_UnusedShowersCut;
 };
 
+class DCutAction_NumUnusedTracks : public DAnalysisAction
+{
+        public:
+
+                DCutAction_NumUnusedTracks(const DParticleCombo* locParticleComboWrapper,  uint locMaxUnusedTracks, string locActionUniqueString = "") :
+                DAnalysisAction(locParticleComboWrapper, "Cut_NumUnusedTracks", false, locActionUniqueString), dMaxUnusedTracks(locMaxUnusedTracks) {}
+
+                string Get_ActionName(void) const;
+                void Initialize(void){};
+                void Reset_NewEvent(void){}
+                bool Perform_Action(void);
+
+        private:
+
+                uint dMaxUnusedTracks;
+};
+
 
 #endif // _DCutActions_

--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -480,7 +480,7 @@ void DHistogramAction_ParticleID::Create_Hists(int locStepIndex, Particle_t locP
 	{
 		locHistName = "ShowerZVsParticleZ";
 		locHistTitle = locParticleROOTName + string(";Particle Vertex Z (cm); Shower Vertex Z (cm)");
-		dHistMap_ShowerZVsParticleZ[locStepIndex][locPID] = new TH2I(locHistName.c_str(), locHistTitle.c_str(), 200, 0., 200., 200, 0., 200);
+		dHistMap_ShowerZVsParticleZ[locStepIndex][locPID] = new TH2I(locHistName.c_str(), locHistTitle.c_str(), 200, 0., 200., 450, 0., 450);
 		locHistName = "ShowerTVsParticleT";
 		locHistTitle = locParticleROOTName + string(";Particle Vertex T (ns); Shower Vertex T (ns)");
 		dHistMap_ShowerTVsParticleT[locStepIndex][locPID] = new TH2I(locHistName.c_str(), locHistTitle.c_str(), 200, -100., 100., 200, -100., 100);

--- a/libraries/DSelector/DParticleCombo.h
+++ b/libraries/DSelector/DParticleCombo.h
@@ -69,6 +69,9 @@ class DParticleCombo
 		// UNUSED ENERGY:
 		Float_t Get_Energy_UnusedShowers(void) const;
 
+		// UNUSED TRACKS:
+		UChar_t Get_NumUnusedTracks(void) const;
+
 		// EVENT INFO: //Doesn't really belong in DParticleCombo, but much easier to pass into actions this way
 		UInt_t Get_RunNumber(void) const;
 		ULong64_t Get_EventNumber(void) const;
@@ -106,6 +109,7 @@ class DParticleCombo
 
 		DTreeInterface* dTreeInterface;
 		UInt_t* dNumCombos;
+		UChar_t* dNumUnusedTracks;
 		UInt_t dComboIndex; //the index in the particle-data arrays to use to grab particle data (e.g. corresponding to this combo)
 
 		deque<DParticleComboStep*> dParticleComboSteps;
@@ -169,6 +173,9 @@ inline void DParticleCombo::Setup_Branches(void)
 
 	// UNUSED ENERGY:
 	dBranch_Energy_UnusedShowers = dTreeInterface->Get_Branch("Energy_UnusedShowers");
+
+	// UNUSED TRACKS:
+	dNumUnusedTracks = (UChar_t*)dTreeInterface->Get_Branch("NumUnusedTracks")->GetAddress();
 }
 
 inline UInt_t DParticleCombo::Get_NumCombos(void) const
@@ -269,6 +276,12 @@ inline Float_t DParticleCombo::Get_Energy_UnusedShowers(void) const
 	if(dBranch_Energy_UnusedShowers == NULL)
 		return -1.0;
 	return ((Float_t*)dBranch_Energy_UnusedShowers->GetAddress())[dComboIndex];
+}
+
+// UNUSED TRACKS:
+inline UChar_t DParticleCombo::Get_NumUnusedTracks(void) const
+{
+	return *dNumUnusedTracks;
 }
 
 // MISSING


### PR DESCRIPTION
Added ability to get NumUnusedTracks from analysis tree and a DCutAction to cut on NumUnusedTracks.

Useage:

    UInt_t NumUnusedTracks = dComboWrapper->Get_NumUnusedTracks();

    dAnalysisActions.push_back(new DCutAction_NumUnusedTracks(dComboWrapper, 3)); 
