### PR TITLE
# Preemptively add chisq/CL comparison CutAction

### DIFF
--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -1,5 +1,177 @@
 #include "DCutActions.h"
 
+string DCutAction_ChiSqOrCL::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dSecondaryReactionName;
+	return locStream.str();
+}
+
+void DCutAction_ChiSqOrCL::Initialize(void)
+{
+	// CREATE & GOTO MAIN FOLDER
+	CreateAndChangeTo_ActionDirectory();
+        CreateAndChangeTo_Directory("Before");
+
+	string locConstraintString = dParticleComboWrapper->Get_KinFitConstraints();
+	size_t locNumConstraints = dParticleComboWrapper->Get_NumKinFitConstraints();
+	size_t locNumUnknowns = dParticleComboWrapper->Get_NumKinFitUnknowns();
+	size_t locNDF = locNumConstraints - locNumUnknowns;
+
+	ostringstream locHistTitle;
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Primary = new TH1I("ChiSqPerDF_Primary", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Secondary = new TH1I("ChiSqPerDF_Secondary", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "#chi^{2}/NDF comparison; #chi^{2}_secondary; #chi^{2}_primary";
+	dHist_ChiSq_Comparison = new TH2I("ChiSq_Comparison", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF, dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Primary = new TH1I("ConfidenceLevel_Primary", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	int locNumBins = 0;
+	double* locConLevLogBinning = dAnalysisUtilities.Generate_LogBinning(dConLevLowest10Power, 0, dNumBinsPerConLevPower, locNumBins);
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Primary = new TH1I("ConfidenceLevel_LogX_Primary", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Primary = NULL;
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Secondary = new TH1I("ConfidenceLevel_Secondary", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Secondary = new TH1I("ConfidenceLevel_LogX_Secondary", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Secondary = NULL;
+
+	locHistTitle.str("");
+	locHistTitle << "Confidence Level comparision; CL_{secondary}; CL_{primary}";
+	dHist_ConfidenceLevel_Comparison = new TH2I("ConfidenceLevel_Comparison", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0, dNumConLevBins, 0.0, 1.0);
+	
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_Log_Comparison = new TH2I("ConfidenceLevel_Log_Comparison", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning, locNumBins, locConLevLogBinning);
+
+	// Return to the base directory
+	ChangeTo_BaseDirectory();
+
+        // Make a new directory to show the result of the cut
+	CreateAndChangeTo_ActionDirectory();
+        CreateAndChangeTo_Directory("After");
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Primary_post = new TH1I("ChiSqPerDF_Primary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Secondary_post = new TH1I("ChiSqPerDF_Secondary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Primary_post = new TH1I("ConfidenceLevel_Primary_post", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Primary_post = new TH1I("ConfidenceLevel_LogX_Primary_post", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Primary_post = NULL;
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Secondary_post = new TH1I("ConfidenceLevel_Secondary_post", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Secondary_post = new TH1I("ConfidenceLevel_LogX_Secondary_post", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Secondary_post = NULL;
+
+	// Return to the base directory
+	ChangeTo_BaseDirectory();
+}
+
+bool DCutAction_ChiSqOrCL::Perform_Action(void)
+{
+	// Primary
+	double locKinFitChiSqPerDF = dParticleComboWrapper->Get_ChiSq_KinFit()/dParticleComboWrapper->Get_NDF_KinFit();
+	dHist_ChiSqPerDF_Primary->Fill(locKinFitChiSqPerDF);
+
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	dHist_ConfidenceLevel_Primary->Fill(locConfidenceLevel);
+	if(dHist_ConfidenceLevel_LogX_Primary != NULL)
+		dHist_ConfidenceLevel_LogX_Primary->Fill(locConfidenceLevel);
+
+	// Secondary
+	// If the secondary reaction did not have a valid chisq, keep the event by returning true.
+	// Skip filling comparison histograms
+	//if ( locKinFitChiSqPerDF_secondary == -1 )
+	if ( dParticleComboWrapper->Get_ChiSq_KinFit_secondary() == -1 )
+		return true;
+
+	double locKinFitChiSqPerDF_secondary = dParticleComboWrapper->Get_ChiSq_KinFit_secondary()/dParticleComboWrapper->Get_NDF_KinFit_secondary();
+	dHist_ChiSqPerDF_Secondary->Fill(locKinFitChiSqPerDF_secondary);
+
+	double locConfidenceLevel_secondary = dParticleComboWrapper->Get_ConfidenceLevel_KinFit_secondary();
+	dHist_ConfidenceLevel_Secondary->Fill(locConfidenceLevel_secondary);
+	if(dHist_ConfidenceLevel_LogX_Secondary != NULL)
+		dHist_ConfidenceLevel_LogX_Secondary->Fill(locConfidenceLevel_secondary);
+
+	dHist_ChiSq_Comparison->Fill( locKinFitChiSqPerDF_secondary, locKinFitChiSqPerDF );
+	dHist_ConfidenceLevel_Comparison->Fill( locConfidenceLevel_secondary, locConfidenceLevel );
+	if(dHist_ConfidenceLevel_Log_Comparison != NULL)
+		dHist_ConfidenceLevel_Log_Comparison->Fill( locConfidenceLevel_secondary, locConfidenceLevel );
+
+	double ratio;
+	bool locIsKept = true;
+	if ( dIsChiSq )
+	{
+		ratio = locKinFitChiSqPerDF / locKinFitChiSqPerDF_secondary;
+		locIsKept = ( ratio < 1.0*dScaleFactor );
+	}
+	else
+	{
+		ratio = locConfidenceLevel / locConfidenceLevel_secondary;
+		locIsKept = ( ratio > 1.0*dScaleFactor );
+	}
+
+	if ( locIsKept )
+	{
+		dHist_ChiSqPerDF_Primary_post->Fill(locKinFitChiSqPerDF);
+        	dHist_ConfidenceLevel_Primary_post->Fill(locConfidenceLevel);
+		if(dHist_ConfidenceLevel_LogX_Primary_post != NULL)
+                	dHist_ConfidenceLevel_LogX_Primary_post->Fill(locConfidenceLevel);
+	}
+	else
+	{
+		dHist_ChiSqPerDF_Secondary_post->Fill(locKinFitChiSqPerDF_secondary);
+		dHist_ConfidenceLevel_Secondary_post->Fill(locConfidenceLevel_secondary);
+		if(dHist_ConfidenceLevel_LogX_Secondary_post != NULL)
+                	dHist_ConfidenceLevel_LogX_Secondary_post->Fill(locConfidenceLevel_secondary);
+	}
+
+	return locIsKept;
+}
+
 string DCutAction_PIDDeltaT::Get_ActionName(void) const
 {
 	ostringstream locStream;
@@ -9,18 +181,6 @@ string DCutAction_PIDDeltaT::Get_ActionName(void) const
 
 void DCutAction_PIDDeltaT::Initialize(void)
 {
-	if (dFunc_PIDCut_SelectPositive == nullptr){
-		dFunc_PIDCut_SelectPositive = new TF1("dFunc_PIDCut_SelectPositive","pol0",0.0, 12.0);
-		dFunc_PIDCut_SelectPositive->SetParameter(0,dDeltaTCut);
-	}
-	else cout << "Using user function for positive PID delta-T cut " << endl;
-
-	if (dFunc_PIDCut_SelectNegative == nullptr){
-		dFunc_PIDCut_SelectNegative = new TF1("dFunc_PIDCut_SelectNegative","pol0",0.0, 12.0);
-		dFunc_PIDCut_SelectNegative->SetParameter(0,-dDeltaTCut);
-	}
-	else cout << "Using user function for negative PID delta-T cut " << endl;	
-	
 	dTargetCenterZ = dParticleComboWrapper->Get_TargetCenter().Z();	
 }
 
@@ -59,16 +219,15 @@ bool DCutAction_PIDDeltaT::Perform_Action(void)
 				if(locNeutralParticleHypothesis != NULL)
 					locSystem = locNeutralParticleHypothesis->Get_Detector_System_Timing();
 			}
-
+			
 			if((dSystem != SYS_NULL) && (locSystem != dSystem))
 				continue;
 
 			TLorentzVector locX4 = dUseKinFitFlag ? locKinematicData->Get_X4() : locKinematicData->Get_X4_Measured();
-			TLorentzVector locP4 = dUseKinFitFlag ? locKinematicData->Get_P4() : locKinematicData->Get_P4_Measured();
 			double locRFTime = dParticleComboWrapper->Get_RFTime_Measured();
 			double locPropagatedRFTime = locRFTime + (locX4.Z() - dTargetCenterZ)/29.9792458;
 			double locDeltaT = locX4.T() - locPropagatedRFTime;
-			if(  locDeltaT > dFunc_PIDCut_SelectPositive->Eval(locP4.P()) || locDeltaT < dFunc_PIDCut_SelectNegative->Eval(locP4.P())) 
+			if(fabs(locDeltaT) > dDeltaTCut) 
 				return false;
 
 		} //end of particle loop
@@ -119,7 +278,7 @@ bool DCutAction_NoPIDHit::Perform_Action(void)
 				if(locNeutralParticleHypothesis != NULL)
 					locSystem = locNeutralParticleHypothesis->Get_Detector_System_Timing();
 			}
-
+			
 			if((dSystem != SYS_NULL) && (locSystem != dSystem))
 				return false;
 
@@ -142,14 +301,14 @@ void DCutAction_dEdx::Initialize(void)
 	{
 		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
 		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_SelectHeavy->SetParameters(dSelectHeavy_c0, dSelectHeavy_c1, dSelectHeavy_c2);
+		dFunc_dEdxCut_SelectHeavy->SetParameters(2.0, 2.0, 1.0);
 	}
 
 	if(dFunc_dEdxCut_SelectLight == NULL)
 	{
 		string locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
 		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_SelectLight->SetParameters(dSelectLight_c0, dSelectLight_c1, dSelectLight_c2);
+		dFunc_dEdxCut_SelectLight->SetParameters(2.0, 0.8, 3.0);
 	}
 }
 
@@ -192,7 +351,7 @@ bool DCutAction_dEdx::Perform_Action(void)
 				continue;
 
 			if(!(locdEdx > 0.0))
-				continue; // Not enough hits in the detector to report a dE/dx: Don't cut
+				return true; // Not enough hits in the detector to report a dE/dx: Don't cut
 
 			//cut
 			double locP = dUseKinFitFlag ? locChargedTrackHypothesis->Get_P4().Vect().Mag() : locChargedTrackHypothesis->Get_P4_Measured().Vect().Mag();
@@ -361,16 +520,22 @@ bool DCutAction_InvariantMassVeto::Perform_Action(void)
 		//build all possible combinations of the included pids
 		set<set<size_t> > locIndexCombos = dAnalysisUtilities.Build_IndexCombos(locComboWrapperStep, dToIncludePIDs);
 
-		//loop over them: Must fail only ONE to fail. only if all succeed, go to the next step
+		//loop over them: Must fail ALL to fail. if any succeed, go to the next step
 		set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+		bool locAnyOKFlag = false;
 		for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
 		{
 			TLorentzVector locFinalStateP4 = dAnalysisUtilities.Calc_FinalStateP4(dParticleComboWrapper, loc_i, *locComboIterator, dUseKinFitFlag);
 			double locInvariantMass = locFinalStateP4.M();
-			if((dMinMass < locInvariantMass) && (locInvariantMass < dMaxMass))
-			  return false;
+			if((locInvariantMass < dMaxMass) && (locInvariantMass > dMinMass))
+				continue;
+			locAnyOKFlag = true;
+			break;
 		}
+		if(!locAnyOKFlag)
+			return false;
 	}
+
 	return true;
 }
 
@@ -445,8 +610,8 @@ bool DCutAction_TrackShowerEOverP::Perform_Action(void)
 				continue;
 
 			TLorentzVector locP4 = dUseKinFitFlag ? locKinematicData->Get_P4() : locKinematicData->Get_P4_Measured();
-			double locP = locP4.P();
-			locShowerEOverP = locShowerEnergy/locP;
+                        double locP = locP4.P();
+                        locShowerEOverP = locShowerEnergy/locP;
 
 			if((dPID == Electron) || (dPID == Positron))
 			{
@@ -463,54 +628,54 @@ bool DCutAction_TrackShowerEOverP::Perform_Action(void)
 
 string DCutAction_TrackBCALPreshowerFraction::Get_ActionName(void) const
 {
-	ostringstream locStream;
-	locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dPreshowerFractionCut;
-	return locStream.str();
+        ostringstream locStream;
+        locStream << DAnalysisAction::Get_ActionName() << "_" << dPID << "_" << dPreshowerFractionCut;
+        return locStream.str();
 }
 
 bool DCutAction_TrackBCALPreshowerFraction::Perform_Action(void)
 {
-	for(size_t loc_i = 0; loc_i < dParticleComboWrapper->Get_NumParticleComboSteps(); ++loc_i)
-	{
-		DParticleComboStep* locComboWrapperStep = dParticleComboWrapper->Get_ParticleComboStep(loc_i);
+        for(size_t loc_i = 0; loc_i < dParticleComboWrapper->Get_NumParticleComboSteps(); ++loc_i)
+        {
+                DParticleComboStep* locComboWrapperStep = dParticleComboWrapper->Get_ParticleComboStep(loc_i);
 
-		//final particles
-		for(size_t loc_j = 0; loc_j < locComboWrapperStep->Get_NumFinalParticles(); ++loc_j)
-		{
-			DKinematicData* locKinematicData = locComboWrapperStep->Get_FinalParticle(loc_j);
-			if(locKinematicData == NULL)
-				continue; //e.g. a decaying or missing particle whose params aren't set yet
-
+                //final particles
+                for(size_t loc_j = 0; loc_j < locComboWrapperStep->Get_NumFinalParticles(); ++loc_j)
+                {
+                        DKinematicData* locKinematicData = locComboWrapperStep->Get_FinalParticle(loc_j);
+                        if(locKinematicData == NULL)
+                                continue; //e.g. a decaying or missing particle whose params aren't set yet
+			
 			//-2 if detected, -1 if missing, > 0 if decaying (step where it is the parent)
 			int locDecayStepIndex = locComboWrapperStep->Get_DecayStepIndex(loc_j);
-			if(locDecayStepIndex != -2)
-				continue; //not measured
-
+                        if(locDecayStepIndex != -2)
+                                continue; //not measured
+			
 			if(locKinematicData->Get_PID() != dPID)
-				continue;
-			if(ParticleCharge(locKinematicData->Get_PID()) == 0)
-				continue;
+                                continue;
+                        if(ParticleCharge(locKinematicData->Get_PID()) == 0)
+                                continue;
 
-			const DChargedTrackHypothesis* locChargedTrackHypothesis = dynamic_cast<const DChargedTrackHypothesis*>(locKinematicData);
-			double locBCALPreshowerE = locChargedTrackHypothesis->Get_Energy_BCALPreshower();
-			double locBCALShowerE = locChargedTrackHypothesis->Get_Energy_BCAL();
-			if(!(locBCALShowerE > 0.0))
-				continue;
+                        const DChargedTrackHypothesis* locChargedTrackHypothesis = dynamic_cast<const DChargedTrackHypothesis*>(locKinematicData);
+                        double locBCALPreshowerE = locChargedTrackHypothesis->Get_Energy_BCALPreshower();
+                        double locBCALShowerE = locChargedTrackHypothesis->Get_Energy_BCAL();
+                        if(!(locBCALShowerE > 0.0))
+                                continue;
 
 			double locPreshowerFraction = locBCALPreshowerE/locBCALShowerE*sin(locChargedTrackHypothesis->Get_P4().Theta());
 
-			if((dPID == Electron) || (dPID == Positron))
-			{
-				if(locPreshowerFraction < dPreshowerFractionCut)
-					return false;
-			}       
+                        if((dPID == Electron) || (dPID == Positron))
+                        {
+                                if(locPreshowerFraction < dPreshowerFractionCut)
+                                        return false;
+                        }       
 			//else if(locPreshowerFraction > dPreshowerFractionCut)
 			//	 return false;
 
 		}
-	}
+        }
 
-	return true;
+        return true;
 }
 
 string DCutAction_Kinematics::Get_ActionName(void) const

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -10,6 +10,8 @@
 #include "TLorentzVector.h"
 #include "TVector3.h"
 #include "TF1.h"
+#include "TH1.h"
+#include "TH2.h"
 
 #include "particleType.h"
 
@@ -25,19 +27,63 @@
 
 using namespace std;
 
-class DCutAction_PIDDeltaT : public DAnalysisAction
+class DCutAction_ChiSqOrCL : public DAnalysisAction
 {
 	public:
-		DCutAction_PIDDeltaT(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, double locDeltaTCut, Particle_t locPID = Unknown, DetectorSystem_t locSystem = SYS_NULL, string locActionUniqueString = "") :
-			DAnalysisAction(locParticleComboWrapper, "Cut_PIDDeltaT", locUseKinFitFlag, locActionUniqueString),
-			dFunc_PIDCut_SelectPositive(nullptr), dFunc_PIDCut_SelectNegative(nullptr), dDeltaTCut(locDeltaTCut), dPID(locPID), dSystem(locSystem) {}
+		DCutAction_ChiSqOrCL(const DParticleCombo* locParticleComboWrapper, string locSecondaryReactionName, bool locIsChiSq, double locScaleFactor, string locActionUniqueString = "") :
+			DAnalysisAction(locParticleComboWrapper, "Cut_ChiSqOrCL", true, locActionUniqueString),
+			dNumChiSqPerDFBins(1000), dNumConLevBins(1000), dNumBinsPerConLevPower(18), dMaxChiSqPerDF(50), dConLevLowest10Power(-50),
+			dSecondaryReactionName(locSecondaryReactionName), dIsChiSq(locIsChiSq), dScaleFactor(locScaleFactor) {}
 
 		string Get_ActionName(void) const;
 		void Initialize(void);
 		void Reset_NewEvent(void){}
 		bool Perform_Action(void);
-		TF1 *dFunc_PIDCut_SelectPositive;
-                TF1 *dFunc_PIDCut_SelectNegative;
+
+		unsigned int dNumChiSqPerDFBins, dNumConLevBins, dNumBinsPerConLevPower;
+		double dMaxChiSqPerDF;
+		int dConLevLowest10Power;
+
+		string dSecondaryReactionName;
+		bool dIsChiSq;
+		double dScaleFactor;
+
+	private:
+
+		DAnalysisUtilities dAnalysisUtilities;
+		
+                // before comparison cut
+		TH1I* dHist_ChiSqPerDF_Primary;
+		TH1I* dHist_ChiSqPerDF_Secondary;
+		TH2I* dHist_ChiSq_Comparison;
+		TH1I* dHist_ConfidenceLevel_Primary;
+		TH1I* dHist_ConfidenceLevel_Secondary;
+		TH2I* dHist_ConfidenceLevel_Comparison;
+		TH1I* dHist_ConfidenceLevel_LogX_Primary;
+		TH1I* dHist_ConfidenceLevel_LogX_Secondary;
+		TH2I* dHist_ConfidenceLevel_Log_Comparison;
+
+                // after comparison cut
+		TH1I* dHist_ChiSqPerDF_Primary_post;
+		TH1I* dHist_ChiSqPerDF_Secondary_post;
+		TH1I* dHist_ConfidenceLevel_Primary_post;
+		TH1I* dHist_ConfidenceLevel_Secondary_post;
+		TH1I* dHist_ConfidenceLevel_LogX_Primary_post;
+		TH1I* dHist_ConfidenceLevel_LogX_Secondary_post;
+
+};
+
+class DCutAction_PIDDeltaT : public DAnalysisAction
+{
+	public:
+		DCutAction_PIDDeltaT(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, double locDeltaTCut, Particle_t locPID = Unknown, DetectorSystem_t locSystem = SYS_NULL, string locActionUniqueString = "") :
+			DAnalysisAction(locParticleComboWrapper, "Cut_PIDDeltaT", locUseKinFitFlag, locActionUniqueString),
+			dDeltaTCut(locDeltaTCut), dPID(locPID), dSystem(locSystem) {}
+
+		string Get_ActionName(void) const;
+		void Initialize(void);
+		void Reset_NewEvent(void){}
+		bool Perform_Action(void);
 
 	private:
 		double dDeltaTCut;
@@ -69,35 +115,20 @@ class DCutAction_dEdx : public DAnalysisAction
 	public:
 		DCutAction_dEdx(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, Particle_t locPID, DetectorSystem_t locSystem = SYS_CDC, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Cut_dEdx", locUseKinFitFlag, locActionUniqueString),
-			dFunc_dEdxCut_SelectHeavy(NULL), dFunc_dEdxCut_SelectLight(NULL), dPID(locPID), dSystem(locSystem), dMaxRejectionFlag(false),
-			dSelectHeavy_c0(2.0), dSelectHeavy_c1(2.0), dSelectHeavy_c2(1.0), dSelectLight_c0(2.0), dSelectLight_c1(0.8), dSelectLight_c2(3.0){}
+			dPID(locPID), dSystem(locSystem), dFunc_dEdxCut_SelectHeavy(NULL), dFunc_dEdxCut_SelectLight(NULL), dMaxRejectionFlag(false) {}
 
 		string Get_ActionName(void) const;
 		void Initialize(void);
 		void Reset_NewEvent(void){}
 		bool Perform_Action(void);
 
-		void Set_ParametersHeavy( double c0, double c1, double c2){
-		    if (dFunc_dEdxCut_SelectHeavy != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
-		    dSelectHeavy_c0 = c0, dSelectHeavy_c1 = c1, dSelectHeavy_c2 = c2;
-		    return;
-		}
-		void Set_ParametersLight( double c0, double c1, double c2){
-                    if (dFunc_dEdxCut_SelectLight != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
-                    dSelectLight_c0 = c0, dSelectLight_c1 = c1, dSelectLight_c2 = c2;
-                    return;
-                }
-
-		TF1 *dFunc_dEdxCut_SelectHeavy;
-                TF1 *dFunc_dEdxCut_SelectLight;
-
 	private:
 
 		Particle_t dPID;
 		DetectorSystem_t dSystem;
+		TF1 *dFunc_dEdxCut_SelectHeavy;
+		TF1 *dFunc_dEdxCut_SelectLight;
 		bool dMaxRejectionFlag;
-		double dSelectHeavy_c0, dSelectHeavy_c1, dSelectHeavy_c2;
-		double dSelectLight_c0, dSelectLight_c1, dSelectLight_c2;
 };
 
 class DCutAction_KinFitFOM : public DAnalysisAction

--- a/libraries/DSelector/DParticleCombo.h
+++ b/libraries/DSelector/DParticleCombo.h
@@ -63,8 +63,11 @@ class DParticleCombo
 
 		// KINFIT:
 		Float_t Get_ChiSq_KinFit(void) const;
+		Float_t Get_ChiSq_KinFit_secondary(void) const;
 		UInt_t Get_NDF_KinFit(void) const;
+		UInt_t Get_NDF_KinFit_secondary(void) const;
 		Float_t Get_ConfidenceLevel_KinFit(void) const;
+		Float_t Get_ConfidenceLevel_KinFit_secondary(void) const;
 
 		// UNUSED ENERGY:
 		Float_t Get_Energy_UnusedShowers(void) const;
@@ -122,7 +125,9 @@ class DParticleCombo
 		TBranch* dBranch_RFTime_KinFit; //only if spacetime kinematic fit performed
 
 		TBranch* dBranch_ChiSq_KinFit; //only if kinematic fit performed
+		TBranch* dBranch_ChiSq_KinFit_secondary; //only if kinematic fit performed
 		TBranch* dBranch_NDF_KinFit; //only if kinematic fit performed // = 0 if kinematic fit doesn't converge
+		TBranch* dBranch_NDF_KinFit_secondary; //only if kinematic fit performed // = 0 if kinematic fit doesn't converge
 		TBranch* dBranch_Energy_UnusedShowers;
 
 		//Target not necessarily in the particle combo, so add the info here (for convenience)
@@ -165,7 +170,9 @@ inline void DParticleCombo::Setup_Branches(void)
 
 	// KINFIT:
 	dBranch_ChiSq_KinFit = dTreeInterface->Get_Branch("ChiSq_KinFit");
+	dBranch_ChiSq_KinFit_secondary = dTreeInterface->Get_Branch("ChiSq_KinFit_secondary");
 	dBranch_NDF_KinFit = dTreeInterface->Get_Branch("NDF_KinFit");
+	dBranch_NDF_KinFit_secondary = dTreeInterface->Get_Branch("NDF_KinFit_secondary");
 
 	// UNUSED ENERGY:
 	dBranch_Energy_UnusedShowers = dTreeInterface->Get_Branch("Energy_UnusedShowers");
@@ -247,11 +254,25 @@ inline Float_t DParticleCombo::Get_ChiSq_KinFit(void) const
 	return ((Float_t*)dBranch_ChiSq_KinFit->GetAddress())[dComboIndex];
 }
 
+inline Float_t DParticleCombo::Get_ChiSq_KinFit_secondary(void) const
+{
+	if(dBranch_ChiSq_KinFit_secondary == NULL)
+		return -1.0;
+	return ((Float_t*)dBranch_ChiSq_KinFit_secondary->GetAddress())[dComboIndex];
+}
+
 inline UInt_t DParticleCombo::Get_NDF_KinFit(void) const
 {
 	if((dBranch_NDF_KinFit == NULL) || (dKinFitConstraints != "NA"))
 		return dNumKinFitConstraints - dNumKinFitUnknowns;
 	return ((UInt_t*)dBranch_NDF_KinFit->GetAddress())[dComboIndex];
+}
+
+inline UInt_t DParticleCombo::Get_NDF_KinFit_secondary(void) const
+{
+	if((dBranch_NDF_KinFit_secondary == NULL) || (dKinFitConstraints != "NA"))
+		return dNumKinFitConstraints - dNumKinFitUnknowns;
+	return ((UInt_t*)dBranch_NDF_KinFit_secondary->GetAddress())[dComboIndex];
 }
 
 inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit(void) const
@@ -260,6 +281,15 @@ inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit(void) const
 	if(locChiSq < 0.0)
 		return -1.0;
 	UInt_t locNDF = Get_NDF_KinFit();
+	return TMath::Prob(locChiSq, locNDF);
+}
+
+inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit_secondary(void) const
+{
+	Float_t locChiSq = Get_ChiSq_KinFit_secondary();
+	if(locChiSq < 0.0)
+		return -1.0;
+	UInt_t locNDF = Get_NDF_KinFit_secondary();
 	return TMath::Prob(locChiSq, locNDF);
 }
 


### PR DESCRIPTION
- Updated DParticleCombo.h to read new branches ChiSq_KinFit_secondary and NDF_KinFit_secondary
- Updated DParticleCombo.h to get chisq and ndf from secondary branches
- Updated DCutActions.h to include DCutAction_ChiSqOrCL
- Updated DCutActions.cc to include DCutAction_ChiSqOrCL