### PR TITLE
Preemptively add chisq/CL comparison CutAction (correctly this time!)

### DIFF
--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -1,5 +1,177 @@
 #include "DCutActions.h"
 
+#include "DCutActions.h"
+
+string DCutAction_ChiSqOrCL::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dSecondaryReactionName;
+	return locStream.str();
+}
+
+void DCutAction_ChiSqOrCL::Initialize(void)
+{
+	// CREATE & GOTO MAIN FOLDER
+	CreateAndChangeTo_ActionDirectory();
+        CreateAndChangeTo_Directory("Before");
+
+	string locConstraintString = dParticleComboWrapper->Get_KinFitConstraints();
+	size_t locNumConstraints = dParticleComboWrapper->Get_NumKinFitConstraints();
+	size_t locNumUnknowns = dParticleComboWrapper->Get_NumKinFitUnknowns();
+	size_t locNDF = locNumConstraints - locNumUnknowns;
+
+	ostringstream locHistTitle;
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Primary = new TH1I("ChiSqPerDF_Primary", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Secondary = new TH1I("ChiSqPerDF_Secondary", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "#chi^{2}/NDF comparison; #chi^{2}_secondary; #chi^{2}_primary";
+	dHist_ChiSq_Comparison = new TH2I("ChiSq_Comparison", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF, dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Primary = new TH1I("ConfidenceLevel_Primary", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	int locNumBins = 0;
+	double* locConLevLogBinning = dAnalysisUtilities.Generate_LogBinning(dConLevLowest10Power, 0, dNumBinsPerConLevPower, locNumBins);
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Primary = new TH1I("ConfidenceLevel_LogX_Primary", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Primary = NULL;
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Secondary = new TH1I("ConfidenceLevel_Secondary", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Secondary = new TH1I("ConfidenceLevel_LogX_Secondary", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Secondary = NULL;
+
+	locHistTitle.str("");
+	locHistTitle << "Confidence Level comparision; CL_{secondary}; CL_{primary}";
+	dHist_ConfidenceLevel_Comparison = new TH2I("ConfidenceLevel_Comparison", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0, dNumConLevBins, 0.0, 1.0);
+	
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_Log_Comparison = new TH2I("ConfidenceLevel_Log_Comparison", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning, locNumBins, locConLevLogBinning);
+
+	// Return to the base directory
+	ChangeTo_BaseDirectory();
+
+        // Make a new directory to show the result of the cut
+        CreateAndChangeTo_ActionDirectory();
+        CreateAndChangeTo_Directory("After");
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Primary_post = new TH1I("ChiSqPerDF_Primary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Secondary_post = new TH1I("ChiSqPerDF_Secondary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Primary_post = new TH1I("ConfidenceLevel_Primary_post", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Primary_post = new TH1I("ConfidenceLevel_LogX_Primary_post", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Primary_post = NULL;
+
+	locHistTitle.str("");
+	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << ";Confidence Level (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ConfidenceLevel_Secondary_post = new TH1I("ConfidenceLevel_Secondary_post", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
+	if(locConLevLogBinning != NULL)
+		dHist_ConfidenceLevel_LogX_Secondary_post = new TH1I("ConfidenceLevel_LogX_Secondary_post", locHistTitle.str().c_str(), locNumBins, locConLevLogBinning);
+	else
+		dHist_ConfidenceLevel_LogX_Secondary_post = NULL;
+
+	// Return to the base directory
+	ChangeTo_BaseDirectory();
+}
+
+bool DCutAction_ChiSqOrCL::Perform_Action(void)
+{
+	// Primary
+	double locKinFitChiSqPerDF = dParticleComboWrapper->Get_ChiSq_KinFit()/dParticleComboWrapper->Get_NDF_KinFit();
+	dHist_ChiSqPerDF_Primary->Fill(locKinFitChiSqPerDF);
+
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	dHist_ConfidenceLevel_Primary->Fill(locConfidenceLevel);
+	if(dHist_ConfidenceLevel_LogX_Primary != NULL)
+		dHist_ConfidenceLevel_LogX_Primary->Fill(locConfidenceLevel);
+
+	// Secondary
+	// If the secondary reaction did not have a valid chisq, keep the event by returning true.
+	// Skip filling comparison histograms
+	if ( dParticleComboWrapper->Get_ChiSq_KinFit_secondary() == -1 )
+		return true;
+
+	double locKinFitChiSqPerDF_secondary = dParticleComboWrapper->Get_ChiSq_KinFit_secondary()/dParticleComboWrapper->Get_NDF_KinFit_secondary();
+	dHist_ChiSqPerDF_Secondary->Fill(locKinFitChiSqPerDF_secondary);
+
+	double locConfidenceLevel_secondary = dParticleComboWrapper->Get_ConfidenceLevel_KinFit_secondary();
+	dHist_ConfidenceLevel_Secondary->Fill(locConfidenceLevel_secondary);
+	if(dHist_ConfidenceLevel_LogX_Secondary != NULL)
+		dHist_ConfidenceLevel_LogX_Secondary->Fill(locConfidenceLevel_secondary);
+
+	dHist_ChiSq_Comparison->Fill( locKinFitChiSqPerDF_secondary, locKinFitChiSqPerDF );
+	dHist_ConfidenceLevel_Comparison->Fill( locConfidenceLevel_secondary, locConfidenceLevel );
+	if(dHist_ConfidenceLevel_Log_Comparison != NULL)
+		dHist_ConfidenceLevel_Log_Comparison->Fill( locConfidenceLevel_secondary, locConfidenceLevel );
+
+	double ratio;
+	bool locIsKept = true;
+	if ( dIsChiSq )
+	{
+		ratio = locKinFitChiSqPerDF / locKinFitChiSqPerDF_secondary;
+		locIsKept = ( ratio < 1.0*dScaleFactor );
+	}
+	else
+	{
+		ratio = locConfidenceLevel / locConfidenceLevel_secondary;
+		locIsKept = ( ratio > 1.0*dScaleFactor );
+	}
+
+	if ( locIsKept )
+	{
+		dHist_ChiSqPerDF_Primary_post->Fill(locKinFitChiSqPerDF);
+        	dHist_ConfidenceLevel_Primary_post->Fill(locConfidenceLevel);
+		if(dHist_ConfidenceLevel_LogX_Primary_post != NULL)
+                	dHist_ConfidenceLevel_LogX_Primary_post->Fill(locConfidenceLevel);
+	}
+	else
+	{
+		dHist_ChiSqPerDF_Secondary_post->Fill(locKinFitChiSqPerDF_secondary);
+		dHist_ConfidenceLevel_Secondary_post->Fill(locConfidenceLevel_secondary);
+		if(dHist_ConfidenceLevel_LogX_Secondary_post != NULL)
+                	dHist_ConfidenceLevel_LogX_Secondary_post->Fill(locConfidenceLevel_secondary);
+	}
+
+	return locIsKept;
+}
+
 string DCutAction_PIDDeltaT::Get_ActionName(void) const
 {
 	ostringstream locStream;

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -1,7 +1,5 @@
 #include "DCutActions.h"
 
-#include "DCutActions.h"
-
 string DCutAction_ChiSqOrCL::Get_ActionName(void) const
 {
 	ostringstream locStream;

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -25,6 +25,52 @@
 
 using namespace std;
 
+class DCutAction_ChiSqOrCL : public DAnalysisAction
+{
+	public:
+		DCutAction_ChiSqOrCL(const DParticleCombo* locParticleComboWrapper, string locSecondaryReactionName, bool locIsChiSq, double locScaleFactor, string locActionUniqueString = "") :
+			DAnalysisAction(locParticleComboWrapper, "Cut_ChiSqOrCL", true, locActionUniqueString),
+			dNumChiSqPerDFBins(1000), dNumConLevBins(1000), dNumBinsPerConLevPower(18), dMaxChiSqPerDF(50), dConLevLowest10Power(-50),
+			dSecondaryReactionName(locSecondaryReactionName), dIsChiSq(locIsChiSq), dScaleFactor(locScaleFactor) {}
+
+		string Get_ActionName(void) const;
+		void Initialize(void);
+		void Reset_NewEvent(void){}
+		bool Perform_Action(void);
+
+		unsigned int dNumChiSqPerDFBins, dNumConLevBins, dNumBinsPerConLevPower;
+		double dMaxChiSqPerDF;
+		int dConLevLowest10Power;
+
+		string dSecondaryReactionName;
+		bool dIsChiSq;
+		double dScaleFactor;
+
+	private:
+
+		DAnalysisUtilities dAnalysisUtilities;
+		
+                // before comparison cut
+		TH1I* dHist_ChiSqPerDF_Primary;
+		TH1I* dHist_ChiSqPerDF_Secondary;
+		TH2I* dHist_ChiSq_Comparison;
+		TH1I* dHist_ConfidenceLevel_Primary;
+		TH1I* dHist_ConfidenceLevel_Secondary;
+		TH2I* dHist_ConfidenceLevel_Comparison;
+		TH1I* dHist_ConfidenceLevel_LogX_Primary;
+		TH1I* dHist_ConfidenceLevel_LogX_Secondary;
+		TH2I* dHist_ConfidenceLevel_Log_Comparison;
+
+                // after comparison cut
+		TH1I* dHist_ChiSqPerDF_Primary_post;
+		TH1I* dHist_ChiSqPerDF_Secondary_post;
+		TH1I* dHist_ConfidenceLevel_Primary_post;
+		TH1I* dHist_ConfidenceLevel_Secondary_post;
+		TH1I* dHist_ConfidenceLevel_LogX_Primary_post;
+		TH1I* dHist_ConfidenceLevel_LogX_Secondary_post;
+
+};
+
 class DCutAction_PIDDeltaT : public DAnalysisAction
 {
 	public:

--- a/libraries/DSelector/DParticleCombo.h
+++ b/libraries/DSelector/DParticleCombo.h
@@ -63,8 +63,11 @@ class DParticleCombo
 
 		// KINFIT:
 		Float_t Get_ChiSq_KinFit(void) const;
+		Float_t Get_ChiSq_KinFit_secondary(void) const;
 		UInt_t Get_NDF_KinFit(void) const;
+		UInt_t Get_NDF_KinFit_secondary(void) const;
 		Float_t Get_ConfidenceLevel_KinFit(void) const;
+		Float_t Get_ConfidenceLevel_KinFit_secondary(void) const;
 
 		// UNUSED ENERGY:
 		Float_t Get_Energy_UnusedShowers(void) const;
@@ -126,7 +129,9 @@ class DParticleCombo
 		TBranch* dBranch_RFTime_KinFit; //only if spacetime kinematic fit performed
 
 		TBranch* dBranch_ChiSq_KinFit; //only if kinematic fit performed
+		TBranch* dBranch_ChiSq_KinFit_secondary; //only if kinematic fit performed
 		TBranch* dBranch_NDF_KinFit; //only if kinematic fit performed // = 0 if kinematic fit doesn't converge
+		TBranch* dBranch_NDF_KinFit_secondary; //only if kinematic fit performed // = 0 if kinematic fit doesn't converge
 		TBranch* dBranch_Energy_UnusedShowers;
 
 		//Target not necessarily in the particle combo, so add the info here (for convenience)
@@ -169,7 +174,9 @@ inline void DParticleCombo::Setup_Branches(void)
 
 	// KINFIT:
 	dBranch_ChiSq_KinFit = dTreeInterface->Get_Branch("ChiSq_KinFit");
+	dBranch_ChiSq_KinFit_secondary = dTreeInterface->Get_Branch("ChiSq_KinFit_secondary");
 	dBranch_NDF_KinFit = dTreeInterface->Get_Branch("NDF_KinFit");
+	dBranch_NDF_KinFit_secondary = dTreeInterface->Get_Branch("NDF_KinFit_secondary");
 
 	// UNUSED ENERGY:
 	dBranch_Energy_UnusedShowers = dTreeInterface->Get_Branch("Energy_UnusedShowers");
@@ -254,11 +261,25 @@ inline Float_t DParticleCombo::Get_ChiSq_KinFit(void) const
 	return ((Float_t*)dBranch_ChiSq_KinFit->GetAddress())[dComboIndex];
 }
 
+inline Float_t DParticleCombo::Get_ChiSq_KinFit_secondary(void) const
+{
+	if(dBranch_ChiSq_KinFit_secondary == NULL)
+		return -1.0;
+	return ((Float_t*)dBranch_ChiSq_KinFit_secondary->GetAddress())[dComboIndex];
+}
+
 inline UInt_t DParticleCombo::Get_NDF_KinFit(void) const
 {
 	if((dBranch_NDF_KinFit == NULL) || (dKinFitConstraints != "NA"))
 		return dNumKinFitConstraints - dNumKinFitUnknowns;
 	return ((UInt_t*)dBranch_NDF_KinFit->GetAddress())[dComboIndex];
+}
+
+inline UInt_t DParticleCombo::Get_NDF_KinFit_secondary(void) const
+{
+	if((dBranch_NDF_KinFit_secondary == NULL) || (dKinFitConstraints != "NA"))
+		return dNumKinFitConstraints - dNumKinFitUnknowns;
+	return ((UInt_t*)dBranch_NDF_KinFit_secondary->GetAddress())[dComboIndex];
 }
 
 inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit(void) const
@@ -267,6 +288,15 @@ inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit(void) const
 	if(locChiSq < 0.0)
 		return -1.0;
 	UInt_t locNDF = Get_NDF_KinFit();
+	return TMath::Prob(locChiSq, locNDF);
+}
+
+inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit_secondary(void) const
+{
+	Float_t locChiSq = Get_ChiSq_KinFit_secondary();
+	if(locChiSq < 0.0)
+		return -1.0;
+	UInt_t locNDF = Get_NDF_KinFit_secondary();
 	return TMath::Prob(locChiSq, locNDF);
 }
 


### PR DESCRIPTION
- Updated DParticleCombo.h to read new branches ChiSq_KinFit_secondary and NDF_KinFit_secondary
- Updated DParticleCombo.h to get chisq and ndf from secondary branches
- Updated DCutActions.h to include DCutAction_ChiSqOrCL
- Updated DCutActions.cc to include DCutAction_ChiSqOrCL