### PR TITLE
Updates for DCutAction_ChiSqOrCL()

### DIFF
--- a/libraries/DSelector/DAnalysisUtilities.cc
+++ b/libraries/DSelector/DAnalysisUtilities.cc
@@ -21,7 +21,7 @@ TLorentzVector DAnalysisUtilities::Calc_MissingP4(const DParticleCombo* locParti
 {
 	//NOTE: this routine assumes that the p4 of a charged decaying particle with a detached vertex is the same at both vertices!
 	//assumes missing particle is not the beam particle
-	if(locUseKinFitDataFlag && (locParticleComboWrapper->Get_NDF_KinFit() == 0))
+	if(locUseKinFitDataFlag && (locParticleComboWrapper->Get_NDF_KinFit( "" ) == 0))
 		return Calc_MissingP4(locParticleComboWrapper, locStepIndex, locUpToStepIndex, locUpThroughIndices, locSourceObjects, false); //kinematic fit failed
 
 	TLorentzVector locMissingP4;
@@ -93,7 +93,7 @@ TLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locPa
 
 TLorentzVector DAnalysisUtilities::Calc_FinalStateP4(const DParticleCombo* locParticleComboWrapper, size_t locStepIndex, set<size_t> locToIncludeIndices, map<unsigned int, set<Int_t> >& locSourceObjects, bool locUseKinFitDataFlag) const
 {
-	if(locUseKinFitDataFlag && (locParticleComboWrapper->Get_NDF_KinFit() == 0))
+	if(locUseKinFitDataFlag && (locParticleComboWrapper->Get_NDF_KinFit( "" ) == 0))
 		return Calc_FinalStateP4(locParticleComboWrapper, locStepIndex, locToIncludeIndices, locSourceObjects, false); //kinematic fit failed
 
 	TLorentzVector locFinalStateP4;

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -139,18 +139,11 @@ bool DCutAction_ChiSqOrCL::Perform_Action(void)
 	if(dHist_ConfidenceLevel_Log_Comparison != NULL)
 		dHist_ConfidenceLevel_Log_Comparison->Fill( locConfidenceLevel_secondary, locConfidenceLevel );
 
-	double ratio;
 	bool locIsKept = true;
 	if ( dIsChiSq )
-	{
-		ratio = locKinFitChiSqPerDF / locKinFitChiSqPerDF_secondary;
-		locIsKept = ( ratio < 1.0*dScaleFactor );
-	}
+		locIsKept = ( locKinFitChiSqPerDF < dFunction->Eval( locKinFitChiSqPerDF_secondary ) );
 	else
-	{
-		ratio = locConfidenceLevel / locConfidenceLevel_secondary;
-		locIsKept = ( ratio > 1.0*dScaleFactor );
-	}
+		locIsKept = ( locConfidenceLevel > dFunction->Eval( locConfidenceLevel_secondary ) );
 
 	if ( locIsKept )
 	{

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -13,19 +13,18 @@ void DCutAction_ChiSqOrCL::Initialize(void)
 	CreateAndChangeTo_ActionDirectory();
         CreateAndChangeTo_Directory("Before");
 
-	string locConstraintString = dParticleComboWrapper->Get_KinFitConstraints();
 	size_t locNumConstraints = dParticleComboWrapper->Get_NumKinFitConstraints();
 	size_t locNumUnknowns = dParticleComboWrapper->Get_NumKinFitUnknowns();
 	size_t locNDF = locNumConstraints - locNumUnknowns;
 
 	ostringstream locHistTitle;
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << "Initial #chi^{2}/ndf for primary reaction";
 	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ChiSqPerDF_Primary = new TH1I("ChiSqPerDF_Primary", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << "Initial #chi^{2}/ndf for " << dSecondaryReactionName;
 	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ChiSqPerDF_Secondary = new TH1I("ChiSqPerDF_Secondary", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
@@ -35,7 +34,7 @@ void DCutAction_ChiSqOrCL::Initialize(void)
 	dHist_ChiSq_Comparison = new TH2I("ChiSq_Comparison", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF, dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << "Initial confidence level for primary reaction";
 	locHistTitle << ";Confidence Level (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ConfidenceLevel_Primary = new TH1I("ConfidenceLevel_Primary", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
@@ -48,7 +47,7 @@ void DCutAction_ChiSqOrCL::Initialize(void)
 		dHist_ConfidenceLevel_LogX_Primary = NULL;
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << "Initial confidence level for " << dSecondaryReactionName;
 	locHistTitle << ";Confidence Level (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ConfidenceLevel_Secondary = new TH1I("ConfidenceLevel_Secondary", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
@@ -73,19 +72,19 @@ void DCutAction_ChiSqOrCL::Initialize(void)
         CreateAndChangeTo_Directory("After");
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << "Kept #chi^{2}/ndf for primary reaction";
 	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ChiSqPerDF_Primary_post = new TH1I("ChiSqPerDF_Primary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << "Removed #chi^{2}/ndf for " << dSecondaryReactionName;
 	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ChiSqPerDF_Secondary_post = new TH1I("ChiSqPerDF_Secondary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for primary reaction";
+	locHistTitle << "Kept confidence level for primary reaction";
 	locHistTitle << ";Confidence Level (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ConfidenceLevel_Primary_post = new TH1I("ConfidenceLevel_Primary_post", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
@@ -96,7 +95,7 @@ void DCutAction_ChiSqOrCL::Initialize(void)
 		dHist_ConfidenceLevel_LogX_Primary_post = NULL;
 
 	locHistTitle.str("");
-	locHistTitle << "Kinematic Fit Constraints: " << locConstraintString << " for " << dSecondaryReactionName;
+	locHistTitle << "Removed confidence level for " << dSecondaryReactionName;
 	locHistTitle << ";Confidence Level (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
 	dHist_ConfidenceLevel_Secondary_post = new TH1I("ConfidenceLevel_Secondary_post", locHistTitle.str().c_str(), dNumConLevBins, 0.0, 1.0);
@@ -112,10 +111,10 @@ void DCutAction_ChiSqOrCL::Initialize(void)
 bool DCutAction_ChiSqOrCL::Perform_Action(void)
 {
 	// Primary
-	double locKinFitChiSqPerDF = dParticleComboWrapper->Get_ChiSq_KinFit()/dParticleComboWrapper->Get_NDF_KinFit();
+	double locKinFitChiSqPerDF = dParticleComboWrapper->Get_ChiSq_KinFit( "" )/dParticleComboWrapper->Get_NDF_KinFit( "" );
 	dHist_ChiSqPerDF_Primary->Fill(locKinFitChiSqPerDF);
 
-	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( "" );
 	dHist_ConfidenceLevel_Primary->Fill(locConfidenceLevel);
 	if(dHist_ConfidenceLevel_LogX_Primary != NULL)
 		dHist_ConfidenceLevel_LogX_Primary->Fill(locConfidenceLevel);
@@ -123,13 +122,19 @@ bool DCutAction_ChiSqOrCL::Perform_Action(void)
 	// Secondary
 	// If the secondary reaction did not have a valid chisq, keep the event by returning true.
 	// Skip filling comparison histograms
-	if ( dParticleComboWrapper->Get_ChiSq_KinFit_secondary() == -1 )
+	if ( dParticleComboWrapper->Get_ChiSq_KinFit( dSecondaryReactionName ) == -1 )
+	{
+		dHist_ChiSqPerDF_Primary_post->Fill(locKinFitChiSqPerDF);
+        	dHist_ConfidenceLevel_Primary_post->Fill(locConfidenceLevel);
+		if(dHist_ConfidenceLevel_LogX_Primary_post != NULL)
+                	dHist_ConfidenceLevel_LogX_Primary_post->Fill(locConfidenceLevel);
 		return true;
+	}
 
-	double locKinFitChiSqPerDF_secondary = dParticleComboWrapper->Get_ChiSq_KinFit_secondary()/dParticleComboWrapper->Get_NDF_KinFit_secondary();
+	double locKinFitChiSqPerDF_secondary = dParticleComboWrapper->Get_ChiSq_KinFit( dSecondaryReactionName ) / dParticleComboWrapper->Get_NDF_KinFit( dSecondaryReactionName );
 	dHist_ChiSqPerDF_Secondary->Fill(locKinFitChiSqPerDF_secondary);
 
-	double locConfidenceLevel_secondary = dParticleComboWrapper->Get_ConfidenceLevel_KinFit_secondary();
+	double locConfidenceLevel_secondary = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( dSecondaryReactionName );
 	dHist_ConfidenceLevel_Secondary->Fill(locConfidenceLevel_secondary);
 	if(dHist_ConfidenceLevel_LogX_Secondary != NULL)
 		dHist_ConfidenceLevel_LogX_Secondary->Fill(locConfidenceLevel_secondary);
@@ -546,7 +551,7 @@ string DCutAction_KinFitFOM::Get_ActionName(void) const
 
 bool DCutAction_KinFitFOM::Perform_Action(void)
 {
-	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( "" );
 	return (locConfidenceLevel > dMinimumConfidenceLevel);
 }
 

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -78,6 +78,12 @@ void DCutAction_ChiSqOrCL::Initialize(void)
 	dHist_ChiSqPerDF_Primary_post = new TH1I("ChiSqPerDF_Primary_post", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
 
 	locHistTitle.str("");
+	locHistTitle << "Removed #chi^{2}/ndf for primary reaction";
+	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
+	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
+	dHist_ChiSqPerDF_Primary_post_removed = new TH1I("ChiSqPerDF_Primary_post_removed", locHistTitle.str().c_str(), dNumChiSqPerDFBins, 0.0, dMaxChiSqPerDF);
+
+	locHistTitle.str("");
 	locHistTitle << "Removed #chi^{2}/ndf for " << dSecondaryReactionName;
 	locHistTitle << ";Fit #chi^{2}/NDF (" << locNumConstraints;
 	locHistTitle << " Constraints, " << locNumUnknowns << " Unknowns: " << locNDF << "-C Fit);# Combos";
@@ -159,6 +165,7 @@ bool DCutAction_ChiSqOrCL::Perform_Action(void)
 	}
 	else
 	{
+		dHist_ChiSqPerDF_Primary_post_removed->Fill(locKinFitChiSqPerDF);
 		dHist_ChiSqPerDF_Secondary_post->Fill(locKinFitChiSqPerDF_secondary);
 		dHist_ConfidenceLevel_Secondary_post->Fill(locConfidenceLevel_secondary);
 		if(dHist_ConfidenceLevel_LogX_Secondary_post != NULL)

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -30,10 +30,12 @@ using namespace std;
 class DCutAction_ChiSqOrCL : public DAnalysisAction
 {
 	public:
-		DCutAction_ChiSqOrCL(const DParticleCombo* locParticleComboWrapper, string locSecondaryReactionName, bool locIsChiSq, double locScaleFactor, string locActionUniqueString = "") :
+		DCutAction_ChiSqOrCL(const DParticleCombo* locParticleComboWrapper, string locSecondaryReactionName, bool locIsChiSq, TF1 *locFunction, string locActionUniqueString = "") :
+		//DCutAction_ChiSqOrCL(const DParticleCombo* locParticleComboWrapper, string locSecondaryReactionName, bool locIsChiSq, double locScaleFactor, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Cut_ChiSqOrCL", true, locActionUniqueString),
 			dNumChiSqPerDFBins(1000), dNumConLevBins(1000), dNumBinsPerConLevPower(18), dMaxChiSqPerDF(50), dConLevLowest10Power(-50),
-			dSecondaryReactionName(locSecondaryReactionName), dIsChiSq(locIsChiSq), dScaleFactor(locScaleFactor) {}
+			//dSecondaryReactionName(locSecondaryReactionName), dIsChiSq(locIsChiSq), dScaleFactor(locScaleFactor) {}
+			dSecondaryReactionName(locSecondaryReactionName), dIsChiSq(locIsChiSq), dFunction(locFunction) {}
 
 		string Get_ActionName(void) const;
 		void Initialize(void);
@@ -46,7 +48,8 @@ class DCutAction_ChiSqOrCL : public DAnalysisAction
 
 		string dSecondaryReactionName;
 		bool dIsChiSq;
-		double dScaleFactor;
+		TF1 *dFunction;
+		//double dScaleFactor;
 
 	private:
 

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -68,6 +68,7 @@ class DCutAction_ChiSqOrCL : public DAnalysisAction
 
                 // after comparison cut
 		TH1I* dHist_ChiSqPerDF_Primary_post;
+		TH1I* dHist_ChiSqPerDF_Primary_post_removed;
 		TH1I* dHist_ChiSqPerDF_Secondary_post;
 		TH1I* dHist_ConfidenceLevel_Primary_post;
 		TH1I* dHist_ConfidenceLevel_Secondary_post;

--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -744,7 +744,7 @@ void DHistogramAction_InvariantMass::Initialize(void)
 
 bool DHistogramAction_InvariantMass::Perform_Action(void)
 {
-	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( "" );
 
 	for(size_t loc_i = 0; loc_i < dParticleComboWrapper->Get_NumParticleComboSteps(); ++loc_i)
 	{
@@ -869,7 +869,7 @@ bool DHistogramAction_MissingMass::Perform_Action(void)
 			return true;
 	}
 
-	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( "" );
 
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
 	double locBeamEnergy = 0.0;
@@ -978,7 +978,7 @@ bool DHistogramAction_MissingMassSquared::Perform_Action(void)
 			return true;
 	}
 
-	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( "" );
 
 	DKinematicData* locBeamParticle = dParticleComboWrapper->Get_ParticleComboStep(0)->Get_InitialParticle();
 	double locBeamEnergy = 0.0;
@@ -1304,10 +1304,10 @@ void DHistogramAction_KinFitResults::Initialize(void)
 
 bool DHistogramAction_KinFitResults::Perform_Action(void)
 {
-	double locKinFitChiSqPerNDF = dParticleComboWrapper->Get_ChiSq_KinFit()/dParticleComboWrapper->Get_NDF_KinFit();
+	double locKinFitChiSqPerNDF = dParticleComboWrapper->Get_ChiSq_KinFit( "" )/dParticleComboWrapper->Get_NDF_KinFit( "" );
 	dHist_ChiSqPerDF->Fill(locKinFitChiSqPerNDF);
 
-	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit();
+	double locConfidenceLevel = dParticleComboWrapper->Get_ConfidenceLevel_KinFit( "" );
 	dHist_ConfidenceLevel->Fill(locConfidenceLevel);
 	if(dHist_ConfidenceLevel_LogX != NULL)
 		dHist_ConfidenceLevel_LogX->Fill(locConfidenceLevel);

--- a/libraries/DSelector/DParticleCombo.h
+++ b/libraries/DSelector/DParticleCombo.h
@@ -62,12 +62,9 @@ class DParticleCombo
 		TVector3 Get_TargetCenter(void) const;
 
 		// KINFIT:
-		Float_t Get_ChiSq_KinFit(void) const;
-		Float_t Get_ChiSq_KinFit_secondary(void) const;
-		UInt_t Get_NDF_KinFit(void) const;
-		UInt_t Get_NDF_KinFit_secondary(void) const;
-		Float_t Get_ConfidenceLevel_KinFit(void) const;
-		Float_t Get_ConfidenceLevel_KinFit_secondary(void) const;
+		Float_t Get_ChiSq_KinFit(string branch_tag) const;
+		UInt_t Get_NDF_KinFit(string branch_tag) const;
+		Float_t Get_ConfidenceLevel_KinFit(string branch_tag ) const;
 
 		// UNUSED ENERGY:
 		Float_t Get_Energy_UnusedShowers(void) const;
@@ -128,10 +125,6 @@ class DParticleCombo
 		TBranch* dBranch_RFTime_Measured;
 		TBranch* dBranch_RFTime_KinFit; //only if spacetime kinematic fit performed
 
-		TBranch* dBranch_ChiSq_KinFit; //only if kinematic fit performed
-		TBranch* dBranch_ChiSq_KinFit_secondary; //only if kinematic fit performed
-		TBranch* dBranch_NDF_KinFit; //only if kinematic fit performed // = 0 if kinematic fit doesn't converge
-		TBranch* dBranch_NDF_KinFit_secondary; //only if kinematic fit performed // = 0 if kinematic fit doesn't converge
 		TBranch* dBranch_Energy_UnusedShowers;
 
 		//Target not necessarily in the particle combo, so add the info here (for convenience)
@@ -171,12 +164,6 @@ inline void DParticleCombo::Setup_Branches(void)
 	// RF:
 	dBranch_RFTime_Measured = dTreeInterface->Get_Branch("RFTime_Measured");
 	dBranch_RFTime_KinFit = dTreeInterface->Get_Branch("RFTime_KinFit");
-
-	// KINFIT:
-	dBranch_ChiSq_KinFit = dTreeInterface->Get_Branch("ChiSq_KinFit");
-	dBranch_ChiSq_KinFit_secondary = dTreeInterface->Get_Branch("ChiSq_KinFit_secondary");
-	dBranch_NDF_KinFit = dTreeInterface->Get_Branch("NDF_KinFit");
-	dBranch_NDF_KinFit_secondary = dTreeInterface->Get_Branch("NDF_KinFit_secondary");
 
 	// UNUSED ENERGY:
 	dBranch_Energy_UnusedShowers = dTreeInterface->Get_Branch("Energy_UnusedShowers");
@@ -254,49 +241,36 @@ inline TVector3 DParticleCombo::Get_TargetCenter(void) const
 }
 
 // KINFIT:
-inline Float_t DParticleCombo::Get_ChiSq_KinFit(void) const
+inline Float_t DParticleCombo::Get_ChiSq_KinFit(string branch_tag) const
 {
-	if(dBranch_ChiSq_KinFit == NULL)
+	TBranch* branch;
+	string b_name = "ChiSq_KinFit";
+	if ( branch_tag != "" )
+		b_name += "_" + branch_tag;
+	branch = dTreeInterface->Get_Branch( b_name );
+	if ( branch == NULL )
 		return -1.0;
-	return ((Float_t*)dBranch_ChiSq_KinFit->GetAddress())[dComboIndex];
+	return ((Float_t*)branch->GetAddress())[dComboIndex];
 }
 
-inline Float_t DParticleCombo::Get_ChiSq_KinFit_secondary(void) const
+inline UInt_t DParticleCombo::Get_NDF_KinFit(string branch_tag) const
 {
-	if(dBranch_ChiSq_KinFit_secondary == NULL)
-		return -1.0;
-	return ((Float_t*)dBranch_ChiSq_KinFit_secondary->GetAddress())[dComboIndex];
-}
-
-inline UInt_t DParticleCombo::Get_NDF_KinFit(void) const
-{
-	if((dBranch_NDF_KinFit == NULL) || (dKinFitConstraints != "NA"))
+	TBranch* branch;
+	string b_name = "NDF_KinFit";
+	if ( branch_tag != "" )
+		b_name += "_" + branch_tag;
+	branch = dTreeInterface->Get_Branch( b_name );
+	if((branch == NULL) || (dKinFitConstraints != "NA"))
 		return dNumKinFitConstraints - dNumKinFitUnknowns;
-	return ((UInt_t*)dBranch_NDF_KinFit->GetAddress())[dComboIndex];
+	return ((UInt_t*)branch->GetAddress())[dComboIndex];
 }
 
-inline UInt_t DParticleCombo::Get_NDF_KinFit_secondary(void) const
+inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit( string branch_tag ) const
 {
-	if((dBranch_NDF_KinFit_secondary == NULL) || (dKinFitConstraints != "NA"))
-		return dNumKinFitConstraints - dNumKinFitUnknowns;
-	return ((UInt_t*)dBranch_NDF_KinFit_secondary->GetAddress())[dComboIndex];
-}
-
-inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit(void) const
-{
-	Float_t locChiSq = Get_ChiSq_KinFit();
+	Float_t locChiSq = Get_ChiSq_KinFit( branch_tag );
 	if(locChiSq < 0.0)
 		return -1.0;
-	UInt_t locNDF = Get_NDF_KinFit();
-	return TMath::Prob(locChiSq, locNDF);
-}
-
-inline Float_t DParticleCombo::Get_ConfidenceLevel_KinFit_secondary(void) const
-{
-	Float_t locChiSq = Get_ChiSq_KinFit_secondary();
-	if(locChiSq < 0.0)
-		return -1.0;
-	UInt_t locNDF = Get_NDF_KinFit_secondary();
+	UInt_t locNDF = Get_NDF_KinFit( branch_tag );
 	return TMath::Prob(locChiSq, locNDF);
 }
 

--- a/libraries/DSelector/DSelector.cc
+++ b/libraries/DSelector/DSelector.cc
@@ -617,8 +617,8 @@ void DSelector::Fill_FlatTree(void)
 	dFlatTreeInterface->Fill_Fundamental<Bool_t>("rftime", dComboWrapper->Get_RFTime());
 	if(dTreeInterface->Get_Branch("ChiSq_KinFit") != NULL)
 	{
-		dFlatTreeInterface->Fill_Fundamental<Float_t>("kin_chisq", dComboWrapper->Get_ChiSq_KinFit());
-		dFlatTreeInterface->Fill_Fundamental<UInt_t>("kin_ndf", dComboWrapper->Get_NDF_KinFit());
+		dFlatTreeInterface->Fill_Fundamental<Float_t>("kin_chisq", dComboWrapper->Get_ChiSq_KinFit( "" ));
+		dFlatTreeInterface->Fill_Fundamental<UInt_t>("kin_ndf", dComboWrapper->Get_NDF_KinFit( "" ));
 	}
 
 	//FILL BRANCHES: COMBO


### PR DESCRIPTION
Summary of commits
* Use a TF1 instead of a double, allows for ratio, difference, or more advanced cut
* Can handle multiple reactions by calling the cut multiple times with different unique strings
* Added histogram of removed primary chisq
* Removed unnecessary code