### PR TITLE
New HistogramAction for analyzing cuts

### DIFF
--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -71,45 +71,11 @@ bool DHistogramAction_AnalyzeCutActions::Perform_Action(void)
 		}
 	
 		if (locFill)
-		{
 			Fill_Hists(cut_iter.second, locIndexCombos);
-/*
-			set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
-			for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
-			{
-				map<unsigned int, set<Int_t> > locSourceObjects;
-				TLorentzVector locFinalStateP4 = dAnalysisUtilities.Calc_FinalStateP4(dParticleComboWrapper, dStepIndex, *locComboIterator, locSourceObjects, dUseKinFitFlag);
-				locMass = locFinalStateP4.M();
-				if(dPreviouslyHistogrammed.find(locSourceObjects) == dPreviouslyHistogrammed.end())
-				{
-					dPreviouslyHistogrammed.insert(locSourceObjects);
-					cut_iter.second->Fill(locMass);
-				}
-			}
-*/
-			//don't break: e.g. if multiple pi0's, histogram invariant mass of each one
-		}
 	}
 
 	if (!locComboCut)
-	{
 		Fill_Hists(dHist_InvariantMass_allcuts, locIndexCombos);
-/*
-		dPreviouslyHistogrammed.clear();
-		set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
-		for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
-		{
-			map<unsigned int, set<Int_t> > locSourceObjects;
-			TLorentzVector locFinalStateP4 = dAnalysisUtilities.Calc_FinalStateP4(dParticleComboWrapper, dStepIndex, *locComboIterator, locSourceObjects, dUseKinFitFlag);
-			locMass = locFinalStateP4.M();
-			if(dPreviouslyHistogrammed.find(locSourceObjects) == dPreviouslyHistogrammed.end())
-			{
-				dPreviouslyHistogrammed.insert(locSourceObjects);
-				dHist_InvariantMass_allcuts->Fill(locMass);
-			}
-		}
-*/
-	}
 
 	return true;
 }

--- a/libraries/DSelector/DHistogramActions.cc
+++ b/libraries/DSelector/DHistogramActions.cc
@@ -1,5 +1,138 @@
 #include "DHistogramActions.h"
 
+void DHistogramAction_AnalyzeCutActions::Initialize(void)
+{
+	// CREATE & GO TO MAIN FOLDER
+	CreateAndChangeTo_ActionDirectory();
+
+	double locMassPerBin = 1000.0*(dMaxMass - dMinMass)/( (double)dNumMassBins );
+
+	string locHistTitleBase, locHistTitle;
+	string locHistName = "InvariantMass";
+	string locParticleNamesForHist = "";
+
+	if(dInitialPID != Unknown)
+		locParticleNamesForHist = dParticleComboWrapper->Get_DecayChainFinalParticlesROOTNames(dInitialPID, dUseKinFitFlag);
+	else
+	{
+		for(size_t loc_i = 0; loc_i < dToIncludePIDs.size(); ++loc_i)
+			locParticleNamesForHist += ParticleName_ROOT(dToIncludePIDs[loc_i]);
+	}
+
+	ostringstream locStream;
+	locStream << locMassPerBin;
+	locHistTitleBase = string(";") + locParticleNamesForHist + string(" Invariant Mass (GeV/c^{2}); # Combos / ") + locStream.str() + string(" MeV/c^{2}");
+	locHistTitle = string("After all cuts") + locHistTitleBase;
+	dHist_InvariantMass_allcuts = new TH1I(locHistName.c_str(), locHistTitle.c_str(), dNumMassBins, dMinMass, dMaxMass);
+
+	for (auto const &action_iter : dAllAnalysisActions)
+	{
+		string locActionName = action_iter->Get_ActionName();
+		if (locActionName.find("Cut") != string::npos)
+		{
+			locHistTitle = locActionName + locHistTitleBase;
+			dHistsWithoutCuts[locActionName] = new TH1I( (locHistName + string("_") + locActionName).c_str(), locHistTitle.c_str(), dNumMassBins, dMinMass, dMaxMass);
+		}
+	}
+
+	// RETURN TO BASE DIRECTORY
+	ChangeTo_BaseDirectory();
+	
+}
+
+bool DHistogramAction_AnalyzeCutActions::Perform_Action(void)
+{
+	bool locComboCut = false;
+	//double locMass = 0.0;
+	const DParticleComboStep* locParticleComboStepWrapper = dParticleComboWrapper->Get_ParticleComboStep(dStepIndex);
+
+	//build all possible combinations of the included pids
+	set<set<size_t> > locIndexCombos = dAnalysisUtilities.Build_IndexCombos(locParticleComboStepWrapper, dToIncludePIDs);
+	
+	for (auto const &cut_iter : dHistsWithoutCuts)
+	{
+		dPreviouslyHistogrammed.clear();
+		bool locFill = true;
+		for (auto const &action_iter : dAllAnalysisActions)
+		{
+			string locActionName = action_iter->Get_ActionName();
+			if (locActionName.find("Cut") == string::npos) continue;
+			if (cut_iter.first == locActionName)
+			{
+				if (!action_iter->Perform_Action())
+					locComboCut = true;
+				continue;
+			}
+			if (!action_iter->Perform_Action())
+			{
+				locFill = false;
+				locComboCut = true;
+			}
+		}
+	
+		if (locFill)
+		{
+			Fill_Hists(cut_iter.second, locIndexCombos);
+/*
+			set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+			for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
+			{
+				map<unsigned int, set<Int_t> > locSourceObjects;
+				TLorentzVector locFinalStateP4 = dAnalysisUtilities.Calc_FinalStateP4(dParticleComboWrapper, dStepIndex, *locComboIterator, locSourceObjects, dUseKinFitFlag);
+				locMass = locFinalStateP4.M();
+				if(dPreviouslyHistogrammed.find(locSourceObjects) == dPreviouslyHistogrammed.end())
+				{
+					dPreviouslyHistogrammed.insert(locSourceObjects);
+					cut_iter.second->Fill(locMass);
+				}
+			}
+*/
+			//don't break: e.g. if multiple pi0's, histogram invariant mass of each one
+		}
+	}
+
+	if (!locComboCut)
+	{
+		Fill_Hists(dHist_InvariantMass_allcuts, locIndexCombos);
+/*
+		dPreviouslyHistogrammed.clear();
+		set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+		for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
+		{
+			map<unsigned int, set<Int_t> > locSourceObjects;
+			TLorentzVector locFinalStateP4 = dAnalysisUtilities.Calc_FinalStateP4(dParticleComboWrapper, dStepIndex, *locComboIterator, locSourceObjects, dUseKinFitFlag);
+			locMass = locFinalStateP4.M();
+			if(dPreviouslyHistogrammed.find(locSourceObjects) == dPreviouslyHistogrammed.end())
+			{
+				dPreviouslyHistogrammed.insert(locSourceObjects);
+				dHist_InvariantMass_allcuts->Fill(locMass);
+			}
+		}
+*/
+	}
+
+	return true;
+}
+
+bool DHistogramAction_AnalyzeCutActions::Fill_Hists(TH1I* locHist, set<set<size_t> > locIndexCombos)
+{
+	dPreviouslyHistogrammed.clear();
+	double locMass = 0.0;
+	set<set<size_t> >::iterator locComboIterator = locIndexCombos.begin();
+	for(; locComboIterator != locIndexCombos.end(); ++locComboIterator)
+	{
+		map<unsigned int, set<Int_t> > locSourceObjects;
+		TLorentzVector locFinalStateP4 = dAnalysisUtilities.Calc_FinalStateP4(dParticleComboWrapper, dStepIndex, *locComboIterator, locSourceObjects, dUseKinFitFlag);
+		locMass = locFinalStateP4.M();
+		if(dPreviouslyHistogrammed.find(locSourceObjects) == dPreviouslyHistogrammed.end())
+		{
+			dPreviouslyHistogrammed.insert(locSourceObjects);
+			locHist->Fill(locMass);
+		}
+	}
+	return true;
+}
+
 void DHistogramAction_ParticleComboKinematics::Initialize(void)
 {
 	string locDirName, locHistName, locHistTitle, locStepName, locStepROOTName, locParticleName, locParticleROOTName;

--- a/libraries/DSelector/DHistogramActions.h
+++ b/libraries/DSelector/DHistogramActions.h
@@ -28,6 +28,38 @@
 
 using namespace std;
 
+class DHistogramAction_AnalyzeCutActions : public DAnalysisAction
+{
+	public:
+		DHistogramAction_AnalyzeCutActions(vector<DAnalysisAction*> locAllAnalysisActions, const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, size_t locStepIndex, deque<Particle_t> locToIncludePIDs, unsigned int locNumMassBins, double locMinMass, double locMaxMass, string locActionUniqueString = "") :
+			DAnalysisAction(locParticleComboWrapper, "Hist_AnalyzeCutActions", locUseKinFitFlag, locActionUniqueString),
+			dAllAnalysisActions(locAllAnalysisActions), dInitialPID(Unknown), dStepIndex(locStepIndex), dToIncludePIDs(locToIncludePIDs),
+			dNumMassBins(locNumMassBins), dMinMass(locMinMass), dMaxMass(locMaxMass) {}
+
+		void Reset_NewEvent(void){dPreviouslyHistogrammed.clear();}; //reset uniqueness tracking
+		void Initialize(void);
+		bool Perform_Action(void);
+
+	private:
+		bool Fill_Hists(TH1I* locHist, set<set<size_t>> locIndexCombos);
+		vector<DAnalysisAction*> dAllAnalysisActions;
+		Particle_t dInitialPID;
+		int dStepIndex;
+		deque<Particle_t> dToIncludePIDs;
+
+		unsigned int dNumMassBins;
+		double dMinMass, dMaxMass;
+
+		DAnalysisUtilities dAnalysisUtilities;
+		TH1I* dHist_InvariantMass_allcuts = nullptr;
+
+		// string comes from Get_ActionName() and TH1I* is the histogram without that cut
+		map<string, TH1I*> dHistsWithoutCuts;
+
+		// uniqueness tracking
+		set<map<unsigned int, set<Int_t> > > dPreviouslyHistogrammed;
+};
+
 class DHistogramAction_ParticleComboKinematics : public DAnalysisAction
 {
 	public:

--- a/programs/MakeDSelector/MakeDSelector.cc
+++ b/programs/MakeDSelector/MakeDSelector.cc
@@ -106,7 +106,7 @@ void Print_HeaderFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locHeaderStream << "		bool dIsPARAFlag; //else is PERP or AMO" << endl;
 	locHeaderStream << endl;
 	locHeaderStream << "		// ANALYZE CUT ACTIONS" << endl;
-	locHeaderStream << "		// // Automatically makes mass histograms where one cut is missing
+	locHeaderStream << "		// // Automatically makes mass histograms where one cut is missing" << endl;
 	locHeaderStream << "		DHistogramAction_AnalyzeCutActions* dAnalyzeCutActions;" << endl;
 	locHeaderStream << endl;
 	locHeaderStream << "		//CREATE REACTION-SPECIFIC PARTICLE ARRAYS" << endl;

--- a/programs/MakeDSelector/MakeDSelector.cc
+++ b/programs/MakeDSelector/MakeDSelector.cc
@@ -105,6 +105,10 @@ void Print_HeaderFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locHeaderStream << "		bool dIsPolarizedFlag; //else is AMO" << endl;
 	locHeaderStream << "		bool dIsPARAFlag; //else is PERP or AMO" << endl;
 	locHeaderStream << endl;
+	locHeaderStream << "		// ANALYZE CUT ACTIONS" << endl;
+	locHeaderStream << "		// // Automatically makes mass histograms where one cut is missing
+	locHeaderStream << "		DHistogramAction_AnalyzeCutActions* dAnalyzeCutActions;" << endl;
+	locHeaderStream << endl;
 	locHeaderStream << "		//CREATE REACTION-SPECIFIC PARTICLE ARRAYS" << endl;
 	locHeaderStream << endl;
 
@@ -248,6 +252,12 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << endl;
 	locSourceStream << "	/*********************************** EXAMPLE USER INITIALIZATION: ANALYSIS ACTIONS **********************************/" << endl;
 	locSourceStream << endl;
+	locSourceStream << "	// EXAMPLE: Create deque for histogramming particle masses:" << endl;
+	locSourceStream << "	// // For histogramming the phi mass in phi -> K+ K-" << endl;
+	locSourceStream << "	// // Be sure to change this and dAnalyzeCutActions to match reaction" << endl;
+	locSourceStream << "	std::deque<Particle_t> MyPhi;" << endl;
+	locSourceStream << "	MyPhi.push_back(KPlus); MyPhi.push_back(KMinus);" << endl;
+	locSourceStream << endl;
 	locSourceStream << "	//ANALYSIS ACTIONS: //Executed in order if added to dAnalysisActions" << endl;
 	locSourceStream << "	//false/true below: use measured/kinfit data" << endl;
 	locSourceStream << endl;
@@ -273,9 +283,14 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	//KINEMATICS" << endl;
 	locSourceStream << "	dAnalysisActions.push_back(new DHistogramAction_ParticleComboKinematics(dComboWrapper, false));" << endl;
 	locSourceStream << endl;
+	locSourceStream << "	// ANALYZE CUT ACTIONS" << endl;
+	locSourceStream << "	// // Change MyPhi to match reaction" << endl;
+	locSourceStream << "	dAnalyzeCutActions = new DHistogramAction_AnalyzeCutActions( dAnalysisActions, dComboWrapper, false, 0, MyPhi, 1000, 0.9, 2.4, \"CutActionEffect\" );" << endl;
+	locSourceStream << endl;
 	locSourceStream << "	//INITIALIZE ACTIONS" << endl;
 	locSourceStream << "	//If you create any actions that you want to run manually (i.e. don't add to dAnalysisActions), be sure to initialize them here as well" << endl;
 	locSourceStream << "	Initialize_Actions();" << endl;
+	locSourceStream << "	dAnalyzeCutActions->Initialize(); // manual action, must call Initialize()" << endl;
 	locSourceStream << endl;
 	locSourceStream << "	/******************************** EXAMPLE USER INITIALIZATION: STAND-ALONE HISTOGRAMS *******************************/" << endl;
 	locSourceStream << endl;
@@ -356,6 +371,7 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	//ANALYSIS ACTIONS: Reset uniqueness tracking for each action" << endl;
 	locSourceStream << "	//For any actions that you are executing manually, be sure to call Reset_NewEvent() on them here" << endl;
 	locSourceStream << "	Reset_Actions_NewEvent();" << endl;
+	locSourceStream << "	dAnalyzeCutActions->Reset_NewEvent(); // manual action, must call Reset_NewEvent()" << endl;
 	locSourceStream << endl;
 	locSourceStream << "	//PREVENT-DOUBLE COUNTING WHEN HISTOGRAMMING" << endl;
 	locSourceStream << "		//Sometimes, some content is the exact same between one combo and the next" << endl;
@@ -551,6 +567,7 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "		/******************************************** EXECUTE ANALYSIS ACTIONS *******************************************/" << endl;
 	locSourceStream << endl;
 	locSourceStream << "		// Loop through the analysis actions, executing them in order for the active particle combo" << endl;
+	locSourceStream <<"		dAnalyzeCutActions->Perform_Action(); // Must be executed before Execute_Actions()" << endl;
 	locSourceStream << "		if(!Execute_Actions()) //if the active combo fails a cut, IsComboCutFlag automatically set" << endl;
 	locSourceStream << "			continue;" << endl;
 	locSourceStream << endl;


### PR DESCRIPTION
* Added DHistogramAction_AnalyzeCutActions
* Updated MakeDSelector to automatically set up this action

This action creates invariant mass histograms for each cut action where that cut is left out of the analysis. It can be used to see how effective the given cut is in improving the mass spectrum.

This only works for cut actions added to the analysis actions vector. Any custom cuts within the combo loop are not included.

Due to the structure of the code, this calls each cut action's "Perform_Action()" method twice, once through this action and once through "Execute_Actions()". 