### PR TITLE
Bug fix to thrown info grabbing, return values particular to DMCThrow…

### DIFF
--- a/libraries/DSelector/DMCThrown.h
+++ b/libraries/DSelector/DMCThrown.h
@@ -85,18 +85,19 @@ inline void DMCThrown::ReInitialize(void)
 
 inline Int_t DMCThrown::Get_ParentIndex(void) const
 {
-	return ((Bool_t*)dBranch_ParentIndex->GetAddress())[dMeasuredArrayIndex];
+	return ((Int_t*)dBranch_ParentIndex->GetAddress())[dMeasuredArrayIndex];
 }
 
 inline Int_t DMCThrown::Get_MatchID(void) const
 {
-	return ((Bool_t*)dBranch_MatchID->GetAddress())[dMeasuredArrayIndex];
+	return ((Int_t*)dBranch_MatchID->GetAddress())[dMeasuredArrayIndex];
 }
 
 inline Float_t DMCThrown::Get_MatchFOM(void) const
 {
-	return ((Bool_t*)dBranch_MatchFOM->GetAddress())[dMeasuredArrayIndex];
+	return ((Float_t*)dBranch_MatchFOM->GetAddress())[dMeasuredArrayIndex];
 }
+
 
 #endif //DMCThrown_h
 


### PR DESCRIPTION
…n work now

Previously returned incorrect Bool_t types for DMCThrown::Get_ParentIndex DMCThrown::Get_MatchID and DMCThrown::Get_MatchFOM when actually dealing with Int_t or Double_t types