### PR TITLE
fix order of the particles in output tree

### DIFF
--- a/programs/tree_to_amptools/tree_to_amptools.cc
+++ b/programs/tree_to_amptools/tree_to_amptools.cc
@@ -181,6 +181,14 @@ cout << endl;
 		TObjString* locBranchObjString = new TObjString(locBranchName.c_str());
 		locParticleNamesWithBranches->AddLast(locNameObject);
 		locParticleBranchNames->AddLast(locBranchObjString);
+		if(locParticleName.substr(0, 6) == string("Proton")){
+		  locParticleNamesWithBranches->AddFirst(locNameObject);
+		  locParticleBranchNames->AddFirst(locBranchObjString);
+		}
+		else{
+		  locParticleNamesWithBranches->AddLast(locNameObject);
+		  locParticleBranchNames->AddLast(locBranchObjString);
+		}
 	}
 
 /*
@@ -208,7 +216,10 @@ cout << endl;
 		}
 		if(Check_IfDecayProduct(locDecayProductMap, locParticleName))
 			continue;
-		locTreeParticleNames->AddLast(locNameObject);
+		// Amptools expects to get the recoil proton first
+		if(locParticleName.substr(0, 6) == string("Proton"))
+		  locTreeParticleNames->AddFirst(locNameObject);
+		else locTreeParticleNames->AddLast(locNameObject);
 	}
 
 	cout << endl;

--- a/programs/tree_to_amptools/tree_to_amptools.cc
+++ b/programs/tree_to_amptools/tree_to_amptools.cc
@@ -179,8 +179,6 @@ cout << endl;
 		}
 
 		TObjString* locBranchObjString = new TObjString(locBranchName.c_str());
-		locParticleNamesWithBranches->AddLast(locNameObject);
-		locParticleBranchNames->AddLast(locBranchObjString);
 		if(locParticleName.substr(0, 6) == string("Proton")){
 		  locParticleNamesWithBranches->AddFirst(locNameObject);
 		  locParticleBranchNames->AddFirst(locBranchObjString);
@@ -439,6 +437,8 @@ cout << endl;
 		locInputTree->GetEntry(locEntry);
 
 		//weight
+		if (locMCWeight == 0) // 0 weight in default MC trees does not make sense
+		  locMCWeight = 1.0;
 		*locBranchPointer_Weight = locMCWeight;
 
 		//Loop over combos
@@ -666,6 +666,8 @@ void Convert_ToAmpToolsFormat_MCGen(string locOutputFileName, TTree* locInputTre
 		locInputTree->GetEntry(locEntry);
 
 		//weight
+		if (locMCWeight == 0) // 0 weight in default MC trees does not make sense
+		  locMCWeight = 1.0;
 		*locBranchPointer_Weight = locMCWeight;
 
 		//beam


### PR DESCRIPTION
- the amplitudes defined in halld_sim expect the proton to be in first place in the tree => force the order
- trees produced with gen_amp currently have an MCweight of 0, which does not make sense => set it to 1
