### PR TITLE
use the weights from a combo-dependent branch "DataWeight", if it exists

### DIFF
--- a/programs/tree_to_amptools/tree_to_amptools.cc
+++ b/programs/tree_to_amptools/tree_to_amptools.cc
@@ -282,7 +282,7 @@ void Convert_ToAmpToolsFormat(string locOutputFileName, TTree* locInputTree)
 
 	//set branch addresses for input tree
 	//mc weight
-	Float_t locMCWeight;// = 1.0;
+	Float_t locMCWeight = 1.0;
 	if(locInputTree->FindBranch("MCWeight") != NULL)
 		locInputTree->SetBranchAddress("MCWeight", &locMCWeight);
 
@@ -474,7 +474,7 @@ cout << endl;
 			if(locIsComboCutArray[locComboIndex] == kTRUE)
 				continue;
 
-			if (hasDataWeights){
+			if (hasDataWeights && (locWeight != 0)){
 			  Float_t* locDataWeightArray = (Float_t*)locInputTree->GetBranch("DataWeight")->GetAddress();
 			  *locBranchPointer_Weight = locDataWeightArray[locComboIndex];
 			}

--- a/programs/tree_to_amptools/tree_to_amptools.cc
+++ b/programs/tree_to_amptools/tree_to_amptools.cc
@@ -474,7 +474,7 @@ cout << endl;
 			if(locIsComboCutArray[locComboIndex] == kTRUE)
 				continue;
 
-			if (hasDataWeights && (locWeight != 0)){
+			if (hasDataWeights && (locWeight == 0)){
 			  Float_t* locDataWeightArray = (Float_t*)locInputTree->GetBranch("DataWeight")->GetAddress();
 			  *locBranchPointer_Weight = locDataWeightArray[locComboIndex];
 			}

--- a/programs/tree_to_amptools/tree_to_amptools.cc
+++ b/programs/tree_to_amptools/tree_to_amptools.cc
@@ -282,7 +282,7 @@ void Convert_ToAmpToolsFormat(string locOutputFileName, TTree* locInputTree)
 
 	//set branch addresses for input tree
 	//mc weight
-	Float_t locMCWeight = 1.0;
+	Float_t locMCWeight;// = 1.0;
 	if(locInputTree->FindBranch("MCWeight") != NULL)
 		locInputTree->SetBranchAddress("MCWeight", &locMCWeight);
 
@@ -305,6 +305,14 @@ void Convert_ToAmpToolsFormat(string locOutputFileName, TTree* locInputTree)
 
 	//is-combo-cut
 	locInputTree->SetBranchAddress("IsComboCut", new Bool_t[locCurrentComboArraySize]);
+
+	//data weight
+	bool hasDataWeights = false;
+	if(locInputTree->FindBranch("DataWeight") != NULL){
+	  hasDataWeights = true;
+	  cout << "Using weights from branch 'DataWeight'! Use '-w' to override." << endl;
+	  locInputTree->SetBranchAddress("DataWeight", new Float_t[locCurrentComboArraySize]);
+	}
 
 	//beam
 	TClonesArray* locBeamP4Array = NULL;
@@ -429,6 +437,10 @@ cout << endl;
 			//IS-COMBO-CUT
 			Increase_ArraySize<Bool_t>(locInputTree, "IsComboCut", locCurrentComboArraySize);
 
+			//DATAWEIGHT
+			if (hasDataWeights)
+			  Increase_ArraySize<Bool_t>(locInputTree, "DataWeight", locCurrentComboArraySize);
+
 			//BEAM
 			Increase_ArraySize<Int_t>(locInputTree, locBeamBranchName, locCurrentComboArraySize);
 
@@ -461,6 +473,11 @@ cout << endl;
 			Bool_t* locIsComboCutArray = (Bool_t*)locInputTree->GetBranch("IsComboCut")->GetAddress();
 			if(locIsComboCutArray[locComboIndex] == kTRUE)
 				continue;
+
+			if (hasDataWeights){
+			  Float_t* locDataWeightArray = (Float_t*)locInputTree->GetBranch("DataWeight")->GetAddress();
+			  *locBranchPointer_Weight = locDataWeightArray[locComboIndex];
+			}
 
 			//GET DETECTED FINAL STATE FOUR-MOMENTA
 			for(Int_t loc_i = 0; loc_i < locNumDirect; ++loc_i)


### PR DESCRIPTION
To create the branch in your DSelector, include in Init():
`dTreeInterface->Create_Branch_FundamentalArray<Float_t>("DataWeight", "NumCombos");`

In Process(), fill the branch at the end of the combo loop:
`dTreeInterface->Fill_Fundamental<Float_t>("DataWeight", locDataWeight, loc_i)`

tree_to_amptools will use these weights when it converts the format. MCWeights is not suitable for accidental subtraction, since it is not combo-dependent. A fixed weight can be still be set with '-w'.