### PR TITLE
handle errors better in the accidental scaling factor code

### DIFF
--- a/libraries/DSelector/DAnalysisUtilities.cc
+++ b/libraries/DSelector/DAnalysisUtilities.cc
@@ -789,7 +789,7 @@ double DAnalysisUtilities::Get_AccidentalScalingFactor(int locRunNumber, double 
 		FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
 		if(locInputFile == NULL) {
 			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
-			exit(1);        // make sure we don't fail silently
+			gSystem->Exit(1);        // make sure we don't fail silently
 			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
@@ -797,22 +797,22 @@ double DAnalysisUtilities::Get_AccidentalScalingFactor(int locRunNumber, double 
 		char buff[1024]; // I HATE char buffers
 		if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 		{
-            vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
-            dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
+            //vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
+            //dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
 			gSystem->ClosePipe(locInputFile);
 			cerr << "Could not parse ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
-			exit(1);        // make sure we don't fail silently
+			gSystem->Exit(1);        // make sure we don't fail silently
 			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
 		//get the second line (where the # is)
 		if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 		{
-            vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
-            dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
+            //vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
+            //dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
 			gSystem->ClosePipe(locInputFile);
 			cerr << "Could not parse ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
-			exit(1);        // make sure we don't fail silently
+			gSystem->Exit(1);        // make sure we don't fail silently
 			return -1.0;    // sanity check, this shouldn't be executed!
 		}
         
@@ -820,15 +820,15 @@ double DAnalysisUtilities::Get_AccidentalScalingFactor(int locRunNumber, double 
         if(strncmp(buff, "Cannot", 6) == 0) 
         {
             // no assignment for this run
-            vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
-            dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
+            //vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
+            //dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
 			gSystem->ClosePipe(locInputFile);
-            return -1.0;
+			cerr << "No data available for ANALYSIS/accidental_scaling_factor, run " << locRunNumber << " from CCDB !" << endl;
+			gSystem->Exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
         }
 
 		istringstream locStringStream(buff);
-		
-		cout << "buff = " << buff << endl;
 
 		//extract it
 		locStringStream >> locHodoscopeHiFactor >> locHodoscopeHiFactorErr >> locHodoscopeLoFactor
@@ -849,7 +849,7 @@ double DAnalysisUtilities::Get_AccidentalScalingFactor(int locRunNumber, double 
 		locCachedValues.push_back(locTAGMEnergyBoundHi);
 		locCachedValues.push_back(locTAGMEnergyBoundLo);
 		
-		//dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;
+		dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;
 	}
 
 	if(locBeamEnergy > locTAGMEnergyBoundHi)
@@ -895,7 +895,7 @@ double DAnalysisUtilities::Get_AccidentalScalingFactorError(int locRunNumber, do
 		FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
 		if(locInputFile == NULL) {
 			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
-			exit(1);        // make sure we don't fail silently
+			gSystem->Exit(1);        // make sure we don't fail silently
 			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
@@ -907,7 +907,7 @@ double DAnalysisUtilities::Get_AccidentalScalingFactorError(int locRunNumber, do
             dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
 			gSystem->ClosePipe(locInputFile);
 			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
-			exit(1);        // make sure we don't fail silently
+			gSystem->Exit(1);        // make sure we don't fail silently
 			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
@@ -918,7 +918,7 @@ double DAnalysisUtilities::Get_AccidentalScalingFactorError(int locRunNumber, do
             dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
 			gSystem->ClosePipe(locInputFile);
 			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
-			exit(1);        // make sure we don't fail silently
+			gSystem->Exit(1);        // make sure we don't fail silently
 			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
@@ -926,10 +926,12 @@ double DAnalysisUtilities::Get_AccidentalScalingFactorError(int locRunNumber, do
         if(strncmp(buff, "Cannot", 6) == 0) 
         {
             // no assignment for this run
-            vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
-            dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
+            //vector<double> locCachedValues = { -1., -1., -1., -1., -1., -1., -1., -1. };
+            //dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;   // give up for this run
 			gSystem->ClosePipe(locInputFile);
-            return -1.0;
+			cerr << "No data available for ANALYSIS/accidental_scaling_factor, run " << locRunNumber << " from CCDB !" << endl;
+			gSystem->Exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
         }
 
 		istringstream locStringStream(buff);

--- a/libraries/DSelector/DAnalysisUtilities.cc
+++ b/libraries/DSelector/DAnalysisUtilities.cc
@@ -695,22 +695,29 @@ double DAnalysisUtilities::Get_BeamBunchPeriod(int locRunNumber)
 	ostringstream locCommandStream;
 	locCommandStream << "ccdb dump PHOTON_BEAM/RF/beam_period -r " << locRunNumber;
 	FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
-	if(locInputFile == NULL)
-		return -1.0;
+	if(locInputFile == NULL) {
+		cerr << "Could not load PHOTON_BEAM/RF/beam_period from CCDB !" << endl;
+		exit(1);        // make sure we don't fail silently
+		return -1.0;    // sanity check, this shouldn't be executed!
+	}
 
 	//get the first line
 	char buff[1024]; // I HATE char buffers
 	if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 	{
 		gSystem->ClosePipe(locInputFile);
-		return -1.0;
+		cerr << "Could not parse PHOTON_BEAM/RF/beam_period from CCDB !" << endl;
+		exit(1);        // make sure we don't fail silently
+		return -1.0;    // sanity check, this shouldn't be executed!
 	}
 
 	//get the second line (where the # is)
 	if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 	{
 		gSystem->ClosePipe(locInputFile);
-		return -1.0;
+		cerr << "Could not parse PHOTON_BEAM/RF/beam_period from CCDB !" << endl;
+		exit(1);        // make sure we don't fail silently		
+		return -1.0;    // sanity check, this shouldn't be executed!
 	}
 	istringstream locStringStream(buff);
 
@@ -780,24 +787,33 @@ double DAnalysisUtilities::Get_AccidentalScalingFactor(int locRunNumber, double 
 		ostringstream locCommandStream;
 		locCommandStream << "ccdb dump ANALYSIS/accidental_scaling_factor -r " << locRunNumber;
 		FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
-		if(locInputFile == NULL)
-			return -1.0;
+		if(locInputFile == NULL) {
+			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
+			exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
+		}
 
 		//get the first line
 		char buff[1024]; // I HATE char buffers
 		if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 		{
 			gSystem->ClosePipe(locInputFile);
-			return -1.0;
+			cerr << "Could not parse ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
+			exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
 		//get the second line (where the # is)
 		if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 		{
 			gSystem->ClosePipe(locInputFile);
-			return -1.0;
+			cerr << "Could not parse ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
+			exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 		istringstream locStringStream(buff);
+		
+		cout << "buff = " << buff << endl;
 
 		//extract it
 		locStringStream >> locHodoscopeHiFactor >> locHodoscopeHiFactorErr >> locHodoscopeLoFactor
@@ -818,7 +834,7 @@ double DAnalysisUtilities::Get_AccidentalScalingFactor(int locRunNumber, double 
 		locCachedValues.push_back(locTAGMEnergyBoundHi);
 		locCachedValues.push_back(locTAGMEnergyBoundLo);
 		
-		dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;
+		//dAccidentalScalingFactor_Cache[locRunNumber] = locCachedValues;
 	}
 	
 	if(locBeamEnergy > locTAGMEnergyBoundHi)
@@ -862,22 +878,29 @@ double DAnalysisUtilities::Get_AccidentalScalingFactorError(int locRunNumber, do
 		ostringstream locCommandStream;
 		locCommandStream << "ccdb dump ANALYSIS/accidental_scaling_factor -r " << locRunNumber;
 		FILE* locInputFile = gSystem->OpenPipe(locCommandStream.str().c_str(), "r");
-		if(locInputFile == NULL)
-			return -1.0;
+		if(locInputFile == NULL) {
+			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
+			exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
+		}
 
 		//get the first line
 		char buff[1024]; // I HATE char buffers
 		if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 		{
 			gSystem->ClosePipe(locInputFile);
-			return -1.0;
+			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
+			exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 
 		//get the second line (where the # is)
 		if(fgets(buff, sizeof(buff), locInputFile) == NULL)
 		{
 			gSystem->ClosePipe(locInputFile);
-			return -1.0;
+			cerr << "Could not load ANALYSIS/accidental_scaling_factor from CCDB !" << endl;
+			exit(1);        // make sure we don't fail silently
+			return -1.0;    // sanity check, this shouldn't be executed!
 		}
 		istringstream locStringStream(buff);
 


### PR DESCRIPTION
if there wasn't an entry for a particular run, all the values returned would be -1 except for the first scaling factor, which would be 0, confusingly enough.  Now it will always return -1 in this case

thanks to Mark Dalton for spotting this