### PR TITLE
Add option to turn off default branches in flat tree output to save d…

### DIFF
--- a/libraries/DSelector/DSelector.cc
+++ b/libraries/DSelector/DSelector.cc
@@ -13,6 +13,21 @@ void DSelector::Init(TTree *locTree)
 	dOption = GetOption(); //optional argument given to TTree::Process()
 	if(fInput != NULL) 
 		dOption = ((TNamed*)fInput->FindObject("OPTIONS"))->GetTitle();
+	
+	// Parse any runtime options here...
+	TString locOptions = dOption;
+	locOptions.ToUpper(); // Want options to be case-insensitive
+	
+	// To reduce disk footprint, can turn off default flat branches at runtime with options flag "DefaultFlatOff"
+	// e.g. execute DSelector with: TreeName->Process("DSelector_name.C+","DefaultFlatOff") (case insensitive)
+	// or, you can change the value of dSaveDefaultFlatBranches in your DSelector
+	if(locOptions.Contains("DEFAULTFLATOFF")) dSaveDefaultFlatBranches=false;
+	if(dSaveDefaultFlatBranches==false) {
+		cout << "DefaultFlatOff specified" << endl; 
+		cout << "DEFAULT FLAT TREE BRANCHES WILL NOT BE SAVED!" << endl;
+		cout << "(this will reduce disk footprint of flat trees)" << endl;
+
+	}
 
 	// SETUP OUTPUT
 	// This must be done BEFORE initializing the DTreeInterface, etc. Why? I have no idea. Probably something to do with gDirectory changing.
@@ -426,6 +441,12 @@ void DSelector::Create_FlatTree(void)
 	bool locIsMCFlag = (dTreeInterface->Get_Branch("MCWeight") != NULL);
 	bool locIsMCGenOnlyFlag = (dTreeInterface->Get_Branch("NumCombos") == NULL);
 
+	// Skip default branches below
+	// (custom branches defined in your DSelector will still be saved)
+	if(!dSaveDefaultFlatBranches) {
+		return; //Stop here
+	}
+
 	//CREATE BRANCHES: MAIN EVENT INFO //Copy memory addresses from main tree, so won't even need to set these branch's data
 	dFlatTreeInterface->Create_Branch_Fundamental<UInt_t>("run", dTreeInterface->Get_BranchMemory_Fundamental<UInt_t>("RunNumber"));
 	dFlatTreeInterface->Create_Branch_Fundamental<ULong64_t>("event", dTreeInterface->Get_BranchMemory_Fundamental<ULong64_t>("EventNumber"));
@@ -650,6 +671,7 @@ void DSelector::Create_FlatBranches(DKinematicData* locParticle, bool locIsMCFla
 
 void DSelector::Fill_FlatTree(void)
 {
+	
 	bool locIsMCFlag = (dTreeInterface->Get_Branch("MCWeight") != NULL);
 	bool locIsMCGenOnlyFlag = (dTreeInterface->Get_Branch("NumCombos") == NULL);
 
@@ -657,6 +679,14 @@ void DSelector::Fill_FlatTree(void)
 	{
 		//CODE SOMETHING HERE!!
 		return;
+	}
+
+	// Fill tree, but not the default branches below
+	// (custom branches defined in your DSelector will still be saved)
+	if(!dSaveDefaultFlatBranches) {
+		//FILL TREE
+		dFlatTreeInterface->Fill_OutputTree("");
+		return; //Stop here
 	}
 
 	//FILL BRANCHES: MAIN COMBO INFO

--- a/libraries/DSelector/DSelector.h
+++ b/libraries/DSelector/DSelector.h
@@ -56,6 +56,7 @@ class DSelector : public TSelector
 		string dOutputTreeFileName; //DEPRECATED!! use dOutputTreeFileNameMap instead!!
 		string dFlatTreeFileName; //for output flat trees
 		string dFlatTreeName; //for output flat trees
+		bool dSaveDefaultFlatBranches; // True by default
 
 		//TREE INTERFACE
 		DTreeInterface* dTreeInterface; //for event-based tree
@@ -195,7 +196,7 @@ inline DSelector::DSelector(TTree* locTree) :
 		dFile(NULL), dOutputFlatTreeFile(NULL), dProofFile(NULL), dOutputFlatTreeProofFile(NULL),
 		dTreeNumber(0), dRunNumber(NULL), dEventNumber(NULL), dL1TriggerBits(NULL), dMCWeight(NULL), dGeneratedEnergy(NULL), dIsThrownTopology(NULL), dX4_Production(NULL),
 		dNumBeam(NULL), dNumChargedHypos(NULL), dNumNeutralHypos(NULL), dNumCombos(NULL), dNumThrown(NULL),
-		dNumPIDThrown_FinalState(NULL), dPIDThrown_Decaying(NULL) {}
+		dNumPIDThrown_FinalState(NULL), dPIDThrown_Decaying(NULL), dSaveDefaultFlatBranches(true) {}
 
 /****************************************************************** GET OBJECT DATA *******************************************************************/
 

--- a/programs/MakeDSelector/MakeDSelector.cc
+++ b/programs/MakeDSelector/MakeDSelector.cc
@@ -240,6 +240,7 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	dOutputTreeFileName = \"\"; //\"\" for none" << endl;
 	locSourceStream << "	dFlatTreeFileName = \"\"; //output flat tree (one combo per tree entry), \"\" for none" << endl;
 	locSourceStream << "	dFlatTreeName = \"\"; //if blank, default name will be chosen" << endl;
+	locSourceStream << "	//dSaveDefaultFlatBranches = false; // False: don't save default branches, reduce disk footprint." << endl;
 	locSourceStream << endl;
 	locSourceStream << "	//Because this function gets called for each TTree in the TChain, we must be careful:" << endl;
 	locSourceStream << "		//We need to re-initialize the tree interface & branch wrappers, but don't want to recreate histograms" << endl;

--- a/programs/MakeDSelector/MakeDSelector.cc
+++ b/programs/MakeDSelector/MakeDSelector.cc
@@ -240,7 +240,7 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	dOutputTreeFileName = \"\"; //\"\" for none" << endl;
 	locSourceStream << "	dFlatTreeFileName = \"\"; //output flat tree (one combo per tree entry), \"\" for none" << endl;
 	locSourceStream << "	dFlatTreeName = \"\"; //if blank, default name will be chosen" << endl;
-	locSourceStream << "	//dSaveDefaultFlatBranches = false; // False: don't save default branches, reduce disk footprint." << endl;
+	locSourceStream << "	//dSaveDefaultFlatBranches = true; // False: don't save default branches, reduce disk footprint." << endl;
 	locSourceStream << endl;
 	locSourceStream << "	//Because this function gets called for each TTree in the TChain, we must be careful:" << endl;
 	locSourceStream << "		//We need to re-initialize the tree interface & branch wrappers, but don't want to recreate histograms" << endl;


### PR DESCRIPTION
…isk footprint. This can be specified in your DSelector (see added commented out code in MakeDSelector), or at runtime with "DefaultFlatOff" in the option string (e.g. run your DSelector with MyReaction__B4_Tree->Process("DSelector_reaction.C+","DefaultFlatOff") instead of normal MyReaction__B4_Tree->Process("DSelector_reaction.C+")