### PR TITLE
PIDFOM

### DIFF
--- a/libraries/DSelector/DChargedTrackHypothesis.h
+++ b/libraries/DSelector/DChargedTrackHypothesis.h
@@ -446,7 +446,10 @@ inline DetectorSystem_t DChargedTrackHypothesis::Get_Detector_System_Timing(void
 // Global PID
 inline Float_t DChargedTrackHypothesis::Get_PIDFOM(void) const
 {
-	return ((Float_t*)dBranch_PIDFOM->GetAddress())[dMeasuredArrayIndex];
+	if(dBranch_PIDFOM == NULL)
+                return -1.;
+	else
+                return ((Float_t*)dBranch_PIDFOM->GetAddress())[dMeasuredArrayIndex];
 }
 
 //HIT ENERGY

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -304,6 +304,46 @@ bool DCutAction_NoPIDHit::Perform_Action(void)
 	return true;
 }
 
+string DCutAction_PIDFOM::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dMinimumConfidenceLevel;
+	return locStream.str();
+}
+
+bool DCutAction_PIDFOM::Perform_Action(void)
+{
+	for(size_t loc_i = 0; loc_i < dParticleComboWrapper->Get_NumParticleComboSteps(); ++loc_i)
+	{
+		DParticleComboStep* locComboWrapperStep = dParticleComboWrapper->Get_ParticleComboStep(loc_i);
+
+		//final particles
+		for(size_t loc_j = 0; loc_j < locComboWrapperStep->Get_NumFinalParticles(); ++loc_j)
+		{
+		DKinematicData* locKinematicData = locComboWrapperStep->Get_FinalParticle(loc_j);
+			if(locKinematicData == NULL)
+				continue; //e.g. a decaying or missing particle whose params aren't set yet
+
+			//-2 if detected, -1 if missing, > 0 if decaying (step where it is the parent)
+			int locDecayStepIndex = locComboWrapperStep->Get_DecayStepIndex(loc_j);
+			if(locDecayStepIndex != -2)
+				continue; //not measured
+
+			if((locKinematicData->Get_PID() != dParticleID) && (dParticleID != Unknown))
+				continue;
+			if(locKinematicData->Get_PID() != 0 && ParticleCharge(locKinematicData->Get_PID()) != 0)
+			{
+				const DChargedTrackHypothesis* locChargedTrackHypothesis = static_cast<const DChargedTrackHypothesis*>(locKinematicData);
+				if((locChargedTrackHypothesis->Get_PIDFOM() < dMinimumConfidenceLevel) && (locChargedTrackHypothesis->Get_NDF_Tracking() > 0))
+					return false;
+				if(dCutNDFZeroFlag && (locChargedTrackHypothesis->Get_NDF_Tracking() == 0))
+					return false;
+			}
+		}
+	}
+	return true;
+}
+
 string DCutAction_EachPIDFOM::Get_ActionName(void) const
 {
 	ostringstream locStream;

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -304,6 +304,46 @@ bool DCutAction_NoPIDHit::Perform_Action(void)
 	return true;
 }
 
+string DCutAction_EachPIDFOM::Get_ActionName(void) const
+{
+	ostringstream locStream;
+	locStream << DAnalysisAction::Get_ActionName() << "_" << dMinimumConfidenceLevel;
+	return locStream.str();
+}
+
+bool DCutAction_EachPIDFOM::Perform_Action(void)
+{
+	for(size_t loc_i = 0; loc_i < dParticleComboWrapper->Get_NumParticleComboSteps(); ++loc_i)
+	{
+		DParticleComboStep* locComboWrapperStep = dParticleComboWrapper->Get_ParticleComboStep(loc_i);
+
+		//final particles
+		for(size_t loc_j = 0; loc_j < locComboWrapperStep->Get_NumFinalParticles(); ++loc_j)
+		{
+		DKinematicData* locKinematicData = locComboWrapperStep->Get_FinalParticle(loc_j);
+			if(locKinematicData == NULL)
+				continue; //e.g. a decaying or missing particle whose params aren't set yet
+
+			//-2 if detected, -1 if missing, > 0 if decaying (step where it is the parent)
+			int locDecayStepIndex = locComboWrapperStep->Get_DecayStepIndex(loc_j);
+			if(locDecayStepIndex != -2)
+				continue; //not measured
+
+			if(ParticleCharge(locKinematicData->Get_PID()) != 0)
+			  {
+			    const DChargedTrackHypothesis* locChargedTrackHypothesis = static_cast<const DChargedTrackHypothesis*>(locKinematicData);
+			    if(dCutNDFZeroFlag && (locChargedTrackHypothesis->Get_NDF_Tracking() == 0))
+			      return false;
+			    if((locChargedTrackHypothesis->Get_PIDFOM() < dMinimumConfidenceLevel) && (locChargedTrackHypothesis->Get_NDF_Tracking() > 0))
+			      return false;
+			  }
+
+		} //end of particle loop
+	} //end of step loop
+
+	return true;
+}
+
 string DCutAction_dEdx::Get_ActionName(void) const
 {
 	ostringstream locStream;

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -116,6 +116,23 @@ class DCutAction_NoPIDHit : public DAnalysisAction
 		DetectorSystem_t dSystem;
 };
 
+class DCutAction_EachPIDFOM : public DAnalysisAction
+{
+	public:
+		DCutAction_EachPIDFOM(const DParticleCombo* locParticleComboWrapper, double locMinimumConfidenceLevel, bool locCutNDFZeroFlag = false, string locActionUniqueString = "") :
+		DAnalysisAction(locParticleComboWrapper, "Cut_EachPIDFOM", false, locActionUniqueString),
+		dMinimumConfidenceLevel(locMinimumConfidenceLevel), dCutNDFZeroFlag(locCutNDFZeroFlag){}
+
+		string Get_ActionName(void) const;
+		void Initialize(void){}
+		void Reset_NewEvent(void){}
+		bool Perform_Action(void);
+
+	private:
+		double dMinimumConfidenceLevel;
+		bool dCutNDFZeroFlag;
+};
+
 class DCutAction_dEdx : public DAnalysisAction
 {
 	public:

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -116,6 +116,24 @@ class DCutAction_NoPIDHit : public DAnalysisAction
 		DetectorSystem_t dSystem;
 };
 
+class DCutAction_PIDFOM : public DAnalysisAction
+{
+	public:
+		DCutAction_PIDFOM(const DParticleCombo* locParticleComboWrapper, Particle_t locParticleID, double locMinimumConfidenceLevel, bool locCutNDFZeroFlag = false, string locActionUniqueString = "") :
+		DAnalysisAction(locParticleComboWrapper, "Cut_PIDFOM", false, locActionUniqueString), 
+		dParticleID(locParticleID), dMinimumConfidenceLevel(locMinimumConfidenceLevel), dCutNDFZeroFlag(locCutNDFZeroFlag){}
+
+		string Get_ActionName(void) const;
+		void Initialize(void){}
+		void Reset_NewEvent(void){}
+		bool Perform_Action(void);
+
+	private:
+		Particle_t dParticleID;
+		double dMinimumConfidenceLevel;
+		bool dCutNDFZeroFlag;
+};
+
 class DCutAction_EachPIDFOM : public DAnalysisAction
 {
 	public:

--- a/libraries/DSelector/DHistogramActions.h
+++ b/libraries/DSelector/DHistogramActions.h
@@ -237,6 +237,38 @@ class DHistogramAction_ParticleID : public DAnalysisAction
 		map<size_t, map<Particle_t, map<Particle_t, set<Int_t> > > > dPreviouslyHistogrammed_Background; //step index, PID, background PID, particle indices
 };
 
+class DHistogramAction_PIDFOM : public DAnalysisAction
+{
+	public:
+		DHistogramAction_PIDFOM(const DParticleCombo* locParticleComboWrapper, string locActionUniqueString = "") :
+                        DAnalysisAction(locParticleComboWrapper, "Hist_PIDFOM", false, locActionUniqueString),
+			dChargedHypoWrapper(NULL), dNumBins(500) {}
+
+		void Initialize(void);
+		bool Perform_Action(void);
+		void Reset_NewEvent(void)
+		{
+			//reset uniqueness tracking
+			dPreviouslyHistogrammed.clear();
+		}
+
+	private:
+		DChargedTrackHypothesis* dChargedHypoWrapper;
+
+	public:
+		unsigned int dNumBins;
+
+	private:
+
+		void Create_Hists(int locStepIndex, Particle_t locPID, string locStepROOTName);
+		void Fill_Hists(const DKinematicData* locKinematicData, size_t locStepIndex);
+
+		//keys are step index, PID //beam has PID Unknown
+		map<size_t, map<Particle_t, TH1I*> > dHistMap_PIDFOM;
+
+		map<size_t, map<Particle_t, set<Int_t> > > dPreviouslyHistogrammed; //step index, PID, particle indices
+};
+
 class DHistogramAction_InvariantMass : public DAnalysisAction
 {
 	public:

--- a/programs/MakeDSelector/MakeDSelector.cc
+++ b/programs/MakeDSelector/MakeDSelector.cc
@@ -268,6 +268,11 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	//below: value: +/- N ns, Unknown: All PIDs, SYS_NULL: all timing systems" << endl;
 	locSourceStream << "	//dAnalysisActions.push_back(new DCutAction_PIDDeltaT(dComboWrapper, false, 0.5, KPlus, SYS_BCAL));" << endl;
 	locSourceStream << endl;
+	locSourceStream << "	//PIDFOM (for charged tracks)" << endl;
+	locSourceStream << "	dAnalysisActions.push_back(new DHistogramAction_PIDFOM(dComboWrapper));" << endl;
+	locSourceStream << "	//dAnalysisActions.push_back(new DCutAction_PIDFOM(dComboWrapper, KPlus, 0.1));" << endl;
+	locSourceStream << "	//dAnalysisActions.push_back(new DCutAction_EachPIDFOM(dComboWrapper, 0.1));" << endl;
+	locSourceStream << endl;
 	locSourceStream << "	//MASSES" << endl;
 	locSourceStream << "	//dAnalysisActions.push_back(new DHistogramAction_InvariantMass(dComboWrapper, false, Lambda, 1000, 1.0, 1.2, \"Lambda\"));" << endl;
 	locSourceStream << "	//dAnalysisActions.push_back(new DHistogramAction_MissingMassSquared(dComboWrapper, false, 1000, -0.1, 0.1));" << endl;


### PR DESCRIPTION
I implemented analysis actions to cut on the particle ID figure-of-merit (PIDFOM) of either individual particles or all of them at the same time. A histogram action that plots the PIDFOM for all particles in the reaction is also included.