### PR TITLE
tree_to_amptools expects masses are constrained if kinFit performed

### DIFF
--- a/programs/tree_to_amptools/tree_to_amptools.cc
+++ b/programs/tree_to_amptools/tree_to_amptools.cc
@@ -287,7 +287,7 @@ void Convert_ToAmpToolsFormat(string locOutputFileName, TTree* locInputTree)
 		locInputTree->SetBranchAddress("MCWeight", &locMCWeight);
 
 	//array sizes
-	UInt_t locCurrentComboArraySize = 2000; //should be more than enough, but will check below anyway and resize if needed
+	UInt_t locCurrentComboArraySize = 1000; //should be more than enough, but will check below anyway and resize if needed
 	UInt_t locNumCombos = 0;
 	TBranch* locBranch_NumCombos = NULL;
 	locInputTree->SetBranchAddress("NumCombos", &locNumCombos, &locBranch_NumCombos);


### PR DESCRIPTION
If any kinematic fit is performed then tree_to_amptools expects that it can get the P4s of the Decaying particles (i.e. pi0 or eta) directly from the tree. These branches with the "Decaying" prefix for instance is only available if the masses are constrained in the Kinematic Fitter which is obviously not always the case. We can check if these "Decaying" branches exist to to see which masses are constrained and get them "directly" and if they don't exist then proceed to the calculation of the P4s through the decay map.