### PR TITLE
A new cut action to use beta to select the PID

### DIFF
--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -99,6 +99,27 @@ class DCutAction_PIDDeltaT : public DAnalysisAction
 		double dTargetCenterZ;
 };
 
+class DCutAction_PIDBeta : public DAnalysisAction
+{
+	public:
+		DCutAction_PIDBeta(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, double locMinBetaCut, double locMaxBetaCut, Particle_t locPID = Unknown, DetectorSystem_t locSystem = SYS_NULL, string locActionUniqueString = "") :
+			DAnalysisAction(locParticleComboWrapper, "Cut_PIDBeta", locUseKinFitFlag, locActionUniqueString),
+			dFunc_BetaCut_SelectPositive(nullptr), dFunc_BetaCut_SelectNegative(nullptr), dMinBetaCut(locMinBetaCut), dMaxBetaCut(locMaxBetaCut), dPID(locPID), dSystem(locSystem) {}
+
+		string Get_ActionName(void) const;
+		void Initialize(void);
+		void Reset_NewEvent(void){}
+		bool Perform_Action(void);
+		TF1 *dFunc_BetaCut_SelectPositive;
+                TF1 *dFunc_BetaCut_SelectNegative;
+
+	private:
+		double dMinBetaCut;
+		double dMaxBetaCut;
+		Particle_t dPID;
+		DetectorSystem_t dSystem;
+};
+
 class DCutAction_NoPIDHit : public DAnalysisAction
 {
 	public:


### PR DESCRIPTION
Requested by @nsjarvis 

By default, the boundaries on beta are used independent of the momentum of the particle. Analogous to other cut actions, momentum-dependent user functions can also be supplied. Here is an example on how to do that in the DSelector::Init():

```
 DCutAction_PIDBeta *myBetaCut = new DCutAction_PIDBeta(dComboWrapper, false, 0.5, 1, Proton, SYS_BCAL);
 TF1* f = new TF1("f","[0]*x + [1]",0.0,12.0);
 f->SetParameters(0.125,0.5);
 myBetaCut->dFunc_BetaCut_SelectNegative = f;
 dAnalysisActions.push_back(myBetaCut);
```
