### PR TITLE
Top level make mmi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gluex_root_analysis_prereqs_version.xml
 libraries/DSelector/Linux_*
 programs/MakeDSelector/Linux_*
 programs/tree_to_amptools/Linux_*
+Linux_*

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ make_programs:
 	make -C programs/MakeDSelector all
 	make -C programs/tree_to_amptools all
 	make -C programs/MakePROOFPackage all
+
+clean:
+	make -C libraries/DSelector clean
+	make -C programs/MakeDSelector clean
+	make -C programs/tree_to_amptools clean
+	make -C programs/MakePROOFPackage clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all: make_libraries make_programs
+
+make_libraries:
+	make -C libraries/DSelector all
+
+make_programs:
+	make -C programs/MakeDSelector all
+	make -C programs/tree_to_amptools all
+	make -C programs/MakePROOFPackage all

--- a/libraries/DSelector/Makefile
+++ b/libraries/DSelector/Makefile
@@ -37,14 +37,14 @@ mkdir_build:
 	mkdir -p $(BMS_OSNAME)/obj
 
 install_it:
-	mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib
-	mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include
-	mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include/DSelector
-	cp $(BMS_OSNAME)/lib/libDSelector.so $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
-	cp *.h $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include/DSelector/
+	mkdir -p ../../$(BMS_OSNAME)/lib
+	mkdir -p ../../$(BMS_OSNAME)/include
+	mkdir -p ../../$(BMS_OSNAME)/include/DSelector
+	cp $(BMS_OSNAME)/lib/libDSelector.so ../../$(BMS_OSNAME)/lib/
+	cp *.h ../../$(BMS_OSNAME)/include/DSelector/
 ifeq ($(IS_CLING), 1)
-	cp $(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
-	cp $(BMS_OSNAME)/obj/DSelectorDict.cc $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
+	cp $(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm ../../$(BMS_OSNAME)/lib/
+	cp $(BMS_OSNAME)/obj/DSelectorDict.cc ../../$(BMS_OSNAME)/lib/
 endif
 
 $(BMS_OSNAME)/obj/DSelectorDict.cc: $(HFILES)
@@ -66,10 +66,10 @@ $(BMS_OSNAME)/lib/libDSelector.so: $(CCFILES)
 
 clean:
 	rm -rf $(BMS_OSNAME)
-	rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/libDSelector.so
+	rm -rf ../../$(BMS_OSNAME)/lib/libDSelector.so
 ifeq ($(IS_CLING), 1)
-	rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm 
-	rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/obj/DSelectorDict.cc
+	rm -rf ../../$(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm 
+	rm -rf ../../$(BMS_OSNAME)/obj/DSelectorDict.cc
 endif
 
 env:

--- a/libraries/DSelector/Makefile
+++ b/libraries/DSelector/Makefile
@@ -33,25 +33,25 @@ install: build_it install_it
 build_it: mkdir_build $(BMS_OSNAME)/lib/libDSelector.so
 
 mkdir_build:
-	@mkdir -p $(BMS_OSNAME)/lib
-	@mkdir -p $(BMS_OSNAME)/obj
+	mkdir -p $(BMS_OSNAME)/lib
+	mkdir -p $(BMS_OSNAME)/obj
 
 install_it:
-	@mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib
-	@mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include
-	@mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include/DSelector
-	@cp $(BMS_OSNAME)/lib/libDSelector.so $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
-	@cp *.h $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include/DSelector/
+	mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib
+	mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include
+	mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include/DSelector
+	cp $(BMS_OSNAME)/lib/libDSelector.so $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
+	cp *.h $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include/DSelector/
 ifeq ($(IS_CLING), 1)
-	@cp $(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
-	@cp $(BMS_OSNAME)/obj/DSelectorDict.cc $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
+	cp $(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
+	cp $(BMS_OSNAME)/obj/DSelectorDict.cc $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/
 endif
 
 $(BMS_OSNAME)/obj/DSelectorDict.cc: $(HFILES)
 	@echo "Generating dictionary DSelectorDict.cc ..."
-	@rm -rf $(BMS_OSNAME)/obj/DSelectorDict.cc
+	rm -rf $(BMS_OSNAME)/obj/DSelectorDict.cc
 ifeq ($(IS_CLING), 1)
-	@rm -rf $(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm 
+	rm -rf $(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm 
 	rootcling $@ -c $(INCLUDE) $^
 else
 	rootcint -f $@ -c $(INCLUDE) $^
@@ -60,16 +60,16 @@ endif
 
 $(BMS_OSNAME)/lib/libDSelector.so: $(CCFILES)
 	@echo "Linking libDSelector.so ..."
-	@rm -f $(BMS_OSNAME)/lib/libDSelector.so
+	rm -f $(BMS_OSNAME)/lib/libDSelector.so
 	g++ $(FLAGS) $(SLIB_OPTION) $(CCFILES) -o $(BMS_OSNAME)/lib/libDSelector.so $(LIBS)
-	@chmod 644 $(BMS_OSNAME)/lib/libDSelector.so
+	chmod 644 $(BMS_OSNAME)/lib/libDSelector.so
 
 clean:
-	@rm -rf $(BMS_OSNAME)
-	@rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/libDSelector.so
+	rm -rf $(BMS_OSNAME)
+	rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/libDSelector.so
 ifeq ($(IS_CLING), 1)
-	@rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm 
-	@rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/obj/DSelectorDict.cc
+	rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/obj/DSelectorDict_rdict.pcm 
+	rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/obj/DSelectorDict.cc
 endif
 
 env:

--- a/make_all.sh
+++ b/make_all.sh
@@ -3,6 +3,7 @@
 # LIBRARIES
 cd libraries
 cd DSelector
+echo info: \"make all\" in libraries/DSelector
 make all
 cd ../../
 

--- a/programs/MakeDSelector/Makefile
+++ b/programs/MakeDSelector/Makefile
@@ -1,12 +1,12 @@
 #! gnumake
 
-INCLUDE = -I. -I$(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include -I$(HALLD_RECON_HOME)/$(BMS_OSNAME)/include
+INCLUDE = -I. -I../../$(BMS_OSNAME)/include -I$(HALLD_RECON_HOME)/$(BMS_OSNAME)/include
 ROOTFLAGS = $(shell $(ROOTSYS)/bin/root-config --cflags)
 CXXFLAGS = -O -Wall -fPIC
 FLAGS = $(CXXFLAGS) $(ROOTFLAGS) $(INCLUDE)
 
 ROOTGLIBS = $(shell $(ROOTSYS)/bin/root-config --glibs)
-LIBS = $(ROOTGLIBS) -L$(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/ -lDSelector
+LIBS = $(ROOTGLIBS) -L../../$(BMS_OSNAME)/lib/ -lDSelector
 
 all: install
 
@@ -18,8 +18,8 @@ mkdir_build:
 	@mkdir -p $(BMS_OSNAME)/bin
 
 install_it:
-	@mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin
-	@cp $(BMS_OSNAME)/bin/MakeDSelector $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin/
+	@mkdir -p ../../$(BMS_OSNAME)/bin
+	@cp $(BMS_OSNAME)/bin/MakeDSelector ../../$(BMS_OSNAME)/bin/
 
 $(BMS_OSNAME)/bin/MakeDSelector: MakeDSelector.cc
 	@rm -f $(BMS_OSNAME)/bin/MakeDSelector
@@ -28,7 +28,7 @@ $(BMS_OSNAME)/bin/MakeDSelector: MakeDSelector.cc
 
 clean:
 	@rm -rf $(BMS_OSNAME)
-	@rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin/MakeDSelector
+	@rm -rf ../../$(BMS_OSNAME)/bin/MakeDSelector
 
 env:
 	@echo C++ $(C++)

--- a/programs/MakeDSelector/Makefile
+++ b/programs/MakeDSelector/Makefile
@@ -21,7 +21,7 @@ install_it:
 	@mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin
 	@cp $(BMS_OSNAME)/bin/MakeDSelector $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin/
 
-$(BMS_OSNAME)/bin/MakeDSelector: MakeDSelector.cc $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/lib/libDSelector.so
+$(BMS_OSNAME)/bin/MakeDSelector: MakeDSelector.cc
 	@rm -f $(BMS_OSNAME)/bin/MakeDSelector
 	g++ $(FLAGS) MakeDSelector.cc -o $(BMS_OSNAME)/bin/MakeDSelector $(LIBS) 
 	@chmod 755 $(BMS_OSNAME)/bin/MakeDSelector

--- a/programs/MakePROOFPackage/.gitignore
+++ b/programs/MakePROOFPackage/.gitignore
@@ -1,0 +1,6 @@
+.directories_made
+.headers_copied
+.libraries_copied
+.proof-inf_created
+DSelector.par
+DSelector

--- a/programs/MakePROOFPackage/Makefile
+++ b/programs/MakePROOFPackage/Makefile
@@ -1,0 +1,42 @@
+PACKAGENAME=DSelector
+DIRNAME=${PACKAGENAME}
+
+all: install
+
+.directories_made:
+	mkdir -p ${DIRNAME}
+	mkdir -p ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/packages/
+	date > .directories_made
+
+#PROOF-INF
+.proof-inf_created: .directories_made
+	mkdir -p ${DIRNAME}/PROOF-INF
+	cp SETUP.C ${DIRNAME}/PROOF-INF/
+	date > $@
+
+#LIBRARIES
+.libraries_copied: .directories_made
+	cp ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/lib/libDSelector.so ${DIRNAME}/
+	date > $@
+
+#HEADERS
+.headers_copied: .directories_made
+	cp -r ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/include/DSelector ${DIRNAME}/
+	cp ${HALLD_RECON_HOME}/${BMS_OSNAME}/include/particleType.h ${DIRNAME}/
+	cp ${HALLD_RECON_HOME}/${BMS_OSNAME}/include/GlueX.h ${DIRNAME}/
+	date > $@
+
+# build archive
+${PACKAGENAME}.par: .proof-inf_created .headers_copied .libraries_copied
+	tar -czf ${PACKAGENAME}.par ${DIRNAME}
+
+# install
+install: ${PACKAGENAME}.par
+	install ${PACKAGENAME}.par ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/packages/
+	@echo ${PACKAGENAME}.par built and installed to ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/packages/
+
+# cleanup
+clean:
+	rm -rf ${DIRNAME}
+
+

--- a/programs/MakePROOFPackage/Makefile
+++ b/programs/MakePROOFPackage/Makefile
@@ -5,7 +5,7 @@ all: install
 
 .directories_made:
 	mkdir -p ${DIRNAME}
-	mkdir -p ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/packages/
+	mkdir -p ../../${BMS_OSNAME}/packages/
 	date > .directories_made
 
 #PROOF-INF
@@ -16,12 +16,12 @@ all: install
 
 #LIBRARIES
 .libraries_copied: .directories_made
-	cp ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/lib/libDSelector.so ${DIRNAME}/
+	cp ../../${BMS_OSNAME}/lib/libDSelector.so ${DIRNAME}/
 	date > $@
 
 #HEADERS
 .headers_copied: .directories_made
-	cp -r ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/include/DSelector ${DIRNAME}/
+	cp -r ../../${BMS_OSNAME}/include/DSelector ${DIRNAME}/
 	cp ${HALLD_RECON_HOME}/${BMS_OSNAME}/include/particleType.h ${DIRNAME}/
 	cp ${HALLD_RECON_HOME}/${BMS_OSNAME}/include/GlueX.h ${DIRNAME}/
 	date > $@
@@ -32,11 +32,11 @@ ${PACKAGENAME}.par: .proof-inf_created .headers_copied .libraries_copied
 
 # install
 install: ${PACKAGENAME}.par
-	install ${PACKAGENAME}.par ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/packages/
-	@echo ${PACKAGENAME}.par built and installed to ${ROOT_ANALYSIS_HOME}/${BMS_OSNAME}/packages/
+	install ${PACKAGENAME}.par ../../${BMS_OSNAME}/packages/
+	@echo ${PACKAGENAME}.par built and installed to ../../${BMS_OSNAME}/packages/
 
 # cleanup
 clean:
-	rm -rf ${DIRNAME}
-
+	rm -rfv ${DIRNAME} .directories_made .proof-inf_created .libraries_copied .headers_copied \
+		${PACKAGENAME}.par
 

--- a/programs/tree_to_amptools/Makefile
+++ b/programs/tree_to_amptools/Makefile
@@ -1,6 +1,6 @@
 #! gnumake
 
-INCLUDE = -I. -I$(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/include -I$(HALLD_RECON_HOME)/$(BMS_OSNAME)/include
+INCLUDE = -I. -I../../$(BMS_OSNAME)/include -I$(HALLD_RECON_HOME)/$(BMS_OSNAME)/include
 ROOTFLAGS = $(shell $(ROOTSYS)/bin/root-config --cflags)
 CXXFLAGS = -O -Wall -fPIC
 FLAGS = $(CXXFLAGS) $(ROOTFLAGS) $(INCLUDE)
@@ -18,8 +18,8 @@ mkdir_build:
 	@mkdir -p $(BMS_OSNAME)/bin
 
 install_it:
-	@mkdir -p $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin
-	@cp $(BMS_OSNAME)/bin/tree_to_amptools $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin/
+	@mkdir -p ../../$(BMS_OSNAME)/bin
+	@cp $(BMS_OSNAME)/bin/tree_to_amptools ../../$(BMS_OSNAME)/bin/
 
 $(BMS_OSNAME)/bin/tree_to_amptools: tree_to_amptools.cc
 	@rm -f $(BMS_OSNAME)/bin/tree_to_amptools
@@ -28,7 +28,7 @@ $(BMS_OSNAME)/bin/tree_to_amptools: tree_to_amptools.cc
 
 clean:
 	@rm -rf $(BMS_OSNAME)
-	@rm -rf $(ROOT_ANALYSIS_HOME)/$(BMS_OSNAME)/bin/tree_to_amptools
+	@rm -rf ../../$(BMS_OSNAME)/bin/tree_to_amptools
 
 env:
 	@echo BMS_OSNAME $(BMS_OSNAME)


### PR DESCRIPTION
Created a makefile at the top-level directory of gluex_root_analysis. It replaces the need for make_all.sh. Also programs/MakePROOFPackage now has a makefile. It replaces the need for build.sh in that directory. Both of the shell script files (make_all.sh and build.sh), though deprecated, are retained for backward compatibility. They may disappear someday.

Also, the dependence of the build on ROOT_ANALYSIS_HOME has been eliminated. The build will be wholly local and thus will proceed in the same way regardless of the value of that environment variable.