### PR TITLE
Nsj dedx cut actions

### DIFF
--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -469,13 +469,22 @@ string DCutAction_dEdx::Get_ActionName(void) const
 	return locStream.str();
 }
 
-void DCutAction_dEdx::Initialize(void)
+void DCutAction_dEdx::Initialize(Particle_t locPID)
 {
 	if(dFunc_dEdxCut_Max == NULL)
 	{
 		string locFuncName = "df_dEdxCut_Max"; //e.g. proton
 		dFunc_dEdxCut_Max = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
 		dFunc_dEdxCut_Max->SetParameters(dMax_c0, dMax_c1, dMax_c2);
+
+                // Set the defaults assuming that the detector is the CDC.  They can be overridden using Set_Max.
+                if((ParticleMass(locPID) - 0.0001) < ParticleMass(KPlus)) {
+		  dFunc_dEdxCut_Max->SetParameters(15, 3.5, 3.3);
+                } else if (locPID == KPlus || locPID == KMinus) {
+		  dFunc_dEdxCut_Max->SetParameters(9, 4.7, 3.3); 
+                } else {
+		  dFunc_dEdxCut_Max->SetParameters(0, 0, 999); 
+                }
 	}
 
 	if(dFunc_dEdxCut_Min == NULL)
@@ -483,6 +492,15 @@ void DCutAction_dEdx::Initialize(void)
 		string locFuncName = "df_dEdxCut_Min"; //e.g. pions, kaons
 		dFunc_dEdxCut_Min = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
 		dFunc_dEdxCut_Min->SetParameters(dMin_c0, dMin_c1, dMin_c2);
+
+                // Set the defaults assuming that the detector is the CDC.  They can be overridden using Set_Min.
+                if((ParticleMass(locPID) - 0.0001) < ParticleMass(KPlus)) {
+		  dFunc_dEdxCut_Min->SetParameters(0, 0, -1);
+                } else if (locPID == KPlus || locPID == KMinus) {
+		  dFunc_dEdxCut_Min->SetParameters(5, 2.6, 0.5); 
+                } else {
+		  dFunc_dEdxCut_Min->SetParameters(4, 3.2, 1.0); 
+                }
 	}
 }
 

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -471,18 +471,18 @@ string DCutAction_dEdx::Get_ActionName(void) const
 
 void DCutAction_dEdx::Initialize(void)
 {
-	if(dFunc_dEdxCut_SelectHeavy == NULL)
+	if(dFunc_dEdxCut_Max == NULL)
 	{
-		string locFuncName = "df_dEdxCut_SelectHeavy"; //e.g. proton
-		dFunc_dEdxCut_SelectHeavy = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_SelectHeavy->SetParameters(dSelectHeavy_c0, dSelectHeavy_c1, dSelectHeavy_c2);
+		string locFuncName = "df_dEdxCut_Max"; //e.g. proton
+		dFunc_dEdxCut_Max = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_Max->SetParameters(dMax_c0, dMax_c1, dMax_c2);
 	}
 
-	if(dFunc_dEdxCut_SelectLight == NULL)
+	if(dFunc_dEdxCut_Min == NULL)
 	{
-		string locFuncName = "df_dEdxCut_SelectLight"; //e.g. pions, kaons
-		dFunc_dEdxCut_SelectLight = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_SelectLight->SetParameters(dSelectLight_c0, dSelectLight_c1, dSelectLight_c2);
+		string locFuncName = "df_dEdxCut_Min"; //e.g. pions, kaons
+		dFunc_dEdxCut_Min = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+		dFunc_dEdxCut_Min->SetParameters(dMin_c0, dMin_c1, dMin_c2);
 	}
 }
 
@@ -529,28 +529,12 @@ bool DCutAction_dEdx::Perform_Action(void)
 
 			//cut
 			double locP = dUseKinFitFlag ? locChargedTrackHypothesis->Get_P4().Vect().Mag() : locChargedTrackHypothesis->Get_P4_Measured().Vect().Mag();
-			if((ParticleMass(locPID) + 0.0001) >= ParticleMass(Proton))
-			{
-				//heavy
-				if(dMaxRejectionFlag) //focus on rejecting background pions
-				{
-					if(locdEdx < dFunc_dEdxCut_SelectLight->Eval(locP))
-						return false;
-				}
-				else if(locdEdx < dFunc_dEdxCut_SelectHeavy->Eval(locP))
+				if(locdEdx < dFunc_dEdxCut_Min->Eval(locP))
+					return false;
+
+				if(locdEdx > dFunc_dEdxCut_Max->Eval(locP))
 					return false; //focus on keeping signal protons
-			}
-			else
-			{
-				//light
-				if(dMaxRejectionFlag) //focus on rejecting background pions
-				{
-					if(locdEdx > dFunc_dEdxCut_SelectHeavy->Eval(locP))
-						return false;
-				}
-				else if(locdEdx > dFunc_dEdxCut_SelectLight->Eval(locP))
-					return false; //focus on keeping signal pions
-			}
+
 		} //end of particle loop
 	} //end of step loop
 

--- a/libraries/DSelector/DCutActions.cc
+++ b/libraries/DSelector/DCutActions.cc
@@ -469,39 +469,52 @@ string DCutAction_dEdx::Get_ActionName(void) const
 	return locStream.str();
 }
 
-void DCutAction_dEdx::Initialize(Particle_t locPID)
+void DCutAction_dEdx::Initialize(void)
 {
-	if(dFunc_dEdxCut_Max == NULL)
-	{
-		string locFuncName = "df_dEdxCut_Max"; //e.g. proton
-		dFunc_dEdxCut_Max = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_Max->SetParameters(dMax_c0, dMax_c1, dMax_c2);
 
-                // Set the defaults assuming that the detector is the CDC.  They can be overridden using Set_Max.
-                if((ParticleMass(locPID) - 0.0001) < ParticleMass(KPlus)) {
-		  dFunc_dEdxCut_Max->SetParameters(15, 3.5, 3.3);
-                } else if (locPID == KPlus || locPID == KMinus) {
-		  dFunc_dEdxCut_Max->SetParameters(9, 4.7, 3.3); 
-                } else {
-		  dFunc_dEdxCut_Max->SetParameters(0, 0, 999); 
-                }
-	}
-
-	if(dFunc_dEdxCut_Min == NULL)
+        if(dFunc_dEdxCut_Min == NULL)   // Set the minimum acceptable dE/dx, the defaults are for the CDC
 	{
-		string locFuncName = "df_dEdxCut_Min"; //e.g. pions, kaons
+		string locFuncName = "df_dEdxCut_Min";
 		dFunc_dEdxCut_Min = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
-		dFunc_dEdxCut_Min->SetParameters(dMin_c0, dMin_c1, dMin_c2);
 
-                // Set the defaults assuming that the detector is the CDC.  They can be overridden using Set_Min.
-                if((ParticleMass(locPID) - 0.0001) < ParticleMass(KPlus)) {
-		  dFunc_dEdxCut_Min->SetParameters(0, 0, -1);
-                } else if (locPID == KPlus || locPID == KMinus) {
-		  dFunc_dEdxCut_Min->SetParameters(5, 2.6, 0.5); 
-                } else {
-		  dFunc_dEdxCut_Min->SetParameters(4, 3.2, 1.0); 
-                }
+                // Set default values for K and p, if the user did not use Set_Min.  
+                if (!dUser_set_min) {
+                  if((dPID == KPlus) || (dPID==KMinus)) {
+                    dMin_c0 = 5;
+                    dMin_c1 = 2.6;
+                    dMin_c2 = 0.5;
+		  } else if(ParticleMass(dPID) > ParticleMass(KPlus)) {   
+                    dMin_c0 = 4;
+                    dMin_c1 = 3.2;
+                    dMin_c2 = 1.0;
+                  } 
+		}
+
+	        dFunc_dEdxCut_Min->SetParameters(dMin_c0, dMin_c1, dMin_c2);
 	}
+
+
+	if(dFunc_dEdxCut_Max == NULL)   // Set the maximum acceptable dE/dx, the defaults are for the CDC
+	{
+		string locFuncName = "df_dEdxCut_Max"; 
+		dFunc_dEdxCut_Max = new TF1(locFuncName.c_str(), "exp(-1.0*[0]*x + [1]) + [2]", 0.0, 12.0);
+
+                // Set default values for pi and K, if the user did not use Set_Max.  
+                if (!dUser_set_max) {
+                  if(ParticleMass(dPID) < ParticleMass(KPlus)) {   
+                    dMax_c0 = 15;
+                    dMax_c1 = 3.5;
+                    dMax_c2 = 3.3;
+                  } else if((dPID == KPlus) || (dPID==KMinus)) {
+                    dMax_c0 = 9;
+                    dMax_c1 = 4.7;
+                    dMax_c2 = 3.3;
+		  }
+		}
+
+	        dFunc_dEdxCut_Max->SetParameters(dMax_c0, dMax_c1, dMax_c2);
+	}
+
 }
 
 bool DCutAction_dEdx::Perform_Action(void)

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -178,7 +178,7 @@ class DCutAction_dEdx : public DAnalysisAction
 		DCutAction_dEdx(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, Particle_t locPID, DetectorSystem_t locSystem = SYS_CDC, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Cut_dEdx", locUseKinFitFlag, locActionUniqueString),
 			dFunc_dEdxCut_Max(NULL), dFunc_dEdxCut_Min(NULL), dPID(locPID), dSystem(locSystem), 
-			dMax_c0(0), dMax_c1(0), dMax_c2(1000), dMin_c0(0), dMin_c1(0), dMin_c2(0){}
+			dMax_c0(0), dMax_c1(0), dMax_c2(999), dMin_c0(0), dMin_c1(0), dMin_c2(-99){}
 
 		string Get_ActionName(void) const;
 		void Initialize(void);

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -177,8 +177,8 @@ class DCutAction_dEdx : public DAnalysisAction
 	public:
 		DCutAction_dEdx(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, Particle_t locPID, DetectorSystem_t locSystem = SYS_CDC, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Cut_dEdx", locUseKinFitFlag, locActionUniqueString),
-			dFunc_dEdxCut_SelectHeavy(NULL), dFunc_dEdxCut_SelectLight(NULL), dPID(locPID), dSystem(locSystem), dMaxRejectionFlag(false),
-			dSelectHeavy_c0(2.0), dSelectHeavy_c1(2.0), dSelectHeavy_c2(1.0), dSelectLight_c0(2.0), dSelectLight_c1(0.8), dSelectLight_c2(3.0){}
+			dFunc_dEdxCut_Max(NULL), dFunc_dEdxCut_Min(NULL), dPID(locPID), dSystem(locSystem), 
+			dMax_c0(0), dMax_c1(0), dMax_c2(1000), dMin_c0(0), dMin_c1(0), dMin_c2(0){}
 
 		string Get_ActionName(void) const;
 		void Initialize(void);
@@ -186,26 +186,25 @@ class DCutAction_dEdx : public DAnalysisAction
 		bool Perform_Action(void);
 
 		void Set_ParametersHeavy( double c0, double c1, double c2){
-		    if (dFunc_dEdxCut_SelectHeavy != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
-		    dSelectHeavy_c0 = c0, dSelectHeavy_c1 = c1, dSelectHeavy_c2 = c2;
+		    if (dFunc_dEdxCut_Max != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
+		    dMax_c0 = c0, dMax_c1 = c1, dMax_c2 = c2;
 		    return;
 		}
 		void Set_ParametersLight( double c0, double c1, double c2){
-                    if (dFunc_dEdxCut_SelectLight != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
-                    dSelectLight_c0 = c0, dSelectLight_c1 = c1, dSelectLight_c2 = c2;
+                    if (dFunc_dEdxCut_Min != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
+                    dMin_c0 = c0, dMin_c1 = c1, dMin_c2 = c2;
                     return;
                 }
 
-		TF1 *dFunc_dEdxCut_SelectHeavy;
-                TF1 *dFunc_dEdxCut_SelectLight;
+		TF1 *dFunc_dEdxCut_Max;
+                TF1 *dFunc_dEdxCut_Min;
 
 	private:
 
 		Particle_t dPID;
 		DetectorSystem_t dSystem;
-		bool dMaxRejectionFlag;
-		double dSelectHeavy_c0, dSelectHeavy_c1, dSelectHeavy_c2;
-		double dSelectLight_c0, dSelectLight_c1, dSelectLight_c2;
+		double dMax_c0, dMax_c1, dMax_c2;
+		double dMin_c0, dMin_c1, dMin_c2;
 };
 
 class DCutAction_KinFitFOM : public DAnalysisAction

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -178,10 +178,10 @@ class DCutAction_dEdx : public DAnalysisAction
 		DCutAction_dEdx(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, Particle_t locPID, DetectorSystem_t locSystem = SYS_CDC, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Cut_dEdx", locUseKinFitFlag, locActionUniqueString),
 			dFunc_dEdxCut_Max(NULL), dFunc_dEdxCut_Min(NULL), dPID(locPID), dSystem(locSystem), 
-			dMax_c0(0), dMax_c1(0), dMax_c2(999), dMin_c0(0), dMin_c1(0), dMin_c2(-99){}
+			dMax_c0(0), dMax_c1(0), dMax_c2(999), dMin_c0(0), dMin_c1(0), dMin_c2(-1){}
 
 		string Get_ActionName(void) const;
-		void Initialize(void);
+		void Initialize(Particle_t locPID);
 		void Reset_NewEvent(void){}
 		bool Perform_Action(void);
 
@@ -195,6 +195,8 @@ class DCutAction_dEdx : public DAnalysisAction
                     dMin_c0 = c0, dMin_c1 = c1, dMin_c2 = c2;
                     return;
                 }
+
+
 
 		TF1 *dFunc_dEdxCut_Max;
                 TF1 *dFunc_dEdxCut_Min;

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -178,21 +178,24 @@ class DCutAction_dEdx : public DAnalysisAction
 		DCutAction_dEdx(const DParticleCombo* locParticleComboWrapper, bool locUseKinFitFlag, Particle_t locPID, DetectorSystem_t locSystem = SYS_CDC, string locActionUniqueString = "") :
 			DAnalysisAction(locParticleComboWrapper, "Cut_dEdx", locUseKinFitFlag, locActionUniqueString),
 			dFunc_dEdxCut_Max(NULL), dFunc_dEdxCut_Min(NULL), dPID(locPID), dSystem(locSystem), 
-			dMax_c0(0), dMax_c1(0), dMax_c2(999), dMin_c0(0), dMin_c1(0), dMin_c2(-1){}
+	         	dMax_c0(0), dMax_c1(0), dMax_c2(999), dMin_c0(0), dMin_c1(0), dMin_c2(-1),
+                        dUser_set_max(false), dUser_set_min(false){}
 
 		string Get_ActionName(void) const;
-		void Initialize(Particle_t locPID);
+		void Initialize(void);
 		void Reset_NewEvent(void){}
 		bool Perform_Action(void);
 
 		void Set_Max( double c0, double c1, double c2){
 		    if (dFunc_dEdxCut_Max != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
-		    dMax_c0 = c0, dMax_c1 = c1, dMax_c2 = c2;
+                    dMax_c0 = c0, dMax_c1 = c1, dMax_c2 = c2;
+                    dUser_set_max = true;
 		    return;
 		}
 		void Set_Min( double c0, double c1, double c2){
                     if (dFunc_dEdxCut_Min != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
                     dMin_c0 = c0, dMin_c1 = c1, dMin_c2 = c2;
+                    dUser_set_min = true;
                     return;
                 }
 
@@ -207,6 +210,8 @@ class DCutAction_dEdx : public DAnalysisAction
 		DetectorSystem_t dSystem;
 		double dMax_c0, dMax_c1, dMax_c2;
 		double dMin_c0, dMin_c1, dMin_c2;
+                bool dUser_set_max;
+                bool dUser_set_min;
 };
 
 class DCutAction_KinFitFOM : public DAnalysisAction

--- a/libraries/DSelector/DCutActions.h
+++ b/libraries/DSelector/DCutActions.h
@@ -185,12 +185,12 @@ class DCutAction_dEdx : public DAnalysisAction
 		void Reset_NewEvent(void){}
 		bool Perform_Action(void);
 
-		void Set_ParametersHeavy( double c0, double c1, double c2){
+		void Set_Max( double c0, double c1, double c2){
 		    if (dFunc_dEdxCut_Max != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
 		    dMax_c0 = c0, dMax_c1 = c1, dMax_c2 = c2;
 		    return;
 		}
-		void Set_ParametersLight( double c0, double c1, double c2){
+		void Set_Min( double c0, double c1, double c2){
                     if (dFunc_dEdxCut_Min != NULL) cout << " DCutAction_dEdx::Initialize() has already been called! These settings will not take effect." << endl;
                     dMin_c0 = c0, dMin_c1 = c1, dMin_c2 = c2;
                     return;


### PR DESCRIPTION
I replaced the restrictive (and confusingly named) SelectLight and SelectHeavy dE/dx cut actions with a simpler Set_Min and Set_Max, which can be used to specify the minimum and maximum acceptable dE/dx.  They can be used alone or together, with no mass requirements - this allows pions to be removed from K+/- events.

eg (sharing for the method, not the values) 
`        DCutAction_dEdx *dCutSTdedxKp = new DCutAction_dEdx(dComboWrapper, true, KPlus, SYS_START,"dCutSTdedxKp");
	dCutSTdedxKp->Set_Min(5, 2.4, 0.6); 
        dCutSTdedxKp->Set_Max(9, 4.3, 3.2); 
        dAnalysisActions.push_back(dCutSTdedxKp);`
        
Example of using a very non-standard function 'BetaMax' that was defined earlier:
`        DCutAction_dEdx *dCutSTdedxKm = new DCutAction_dEdx(dComboWrapper, true, KMinus, SYS_START,"dCutSTdedxKm");
        dCutSTdedxKm->dFunc_dEdxCut_Min = BetaMax;
        dAnalysisActions.push_back(dCutSTdedxKm);`
