### PR TITLE
Add non-default option to save TLorentzVectors as set of four doubles…

### DIFF
--- a/libraries/DSelector/DSelector.cc
+++ b/libraries/DSelector/DSelector.cc
@@ -430,7 +430,7 @@ void DSelector::Create_FlatTree(void)
 	//create flat tree & interface
 	string locTreeName = (dFlatTreeName != "") ? dFlatTreeName : dTreeInterface->Get_TreeName().substr(0, dTreeInterface->Get_TreeName().size() - 5);
 	TTree* locFlatTree = new TTree(locTreeName.c_str(), locTreeName.c_str());
-	dFlatTreeInterface = new DTreeInterface(locFlatTree, false); //false: is output
+	dFlatTreeInterface = new DTreeInterface(locFlatTree, false, dSaveTLorentzVectorsAsFundamentaFlatTree); //false: is output
 
 	//set user info
 	TList* locInputUserInfo = dTreeInterface->Get_UserInfo();

--- a/libraries/DSelector/DSelector.h
+++ b/libraries/DSelector/DSelector.h
@@ -57,6 +57,7 @@ class DSelector : public TSelector
 		string dFlatTreeFileName; //for output flat trees
 		string dFlatTreeName; //for output flat trees
 		bool dSaveDefaultFlatBranches; // True by default
+		bool dSaveTLorentzVectorsAsFundamentaFlatTree; // False by default. True: save TLorentzVector info instead as four doubles, rather than as TLorentzVector objects.
 
 		//TREE INTERFACE
 		DTreeInterface* dTreeInterface; //for event-based tree
@@ -191,7 +192,7 @@ class DSelector : public TSelector
 /******************************************************************** CONSTRUCTOR *********************************************************************/
 
 inline DSelector::DSelector(TTree* locTree) :
-		 dInitializedFlag(false), dOption(""), dOutputFileName(""), dOutputTreeFileName(""), dFlatTreeFileName(""), dSaveDefaultFlatBranches(true), dTreeInterface(NULL), dFlatTreeInterface(NULL),
+		 dInitializedFlag(false), dOption(""), dOutputFileName(""), dOutputTreeFileName(""), dFlatTreeFileName(""), dSaveDefaultFlatBranches(true), dSaveTLorentzVectorsAsFundamentaFlatTree(false), dTreeInterface(NULL), dFlatTreeInterface(NULL),
 		dAnalysisUtilities(DAnalysisUtilities()), dTargetCenter(TVector3()), dTargetP4(TLorentzVector()), dTargetPID(Unknown),
 		dThrownBeam(NULL), dThrownWrapper(NULL), dChargedHypoWrapper(NULL), dNeutralHypoWrapper(NULL),
 		dBeamWrapper(NULL), dComboWrapper(NULL), dAnalysisActions(vector<DAnalysisAction*>()),

--- a/libraries/DSelector/DTreeInterface.h
+++ b/libraries/DSelector/DTreeInterface.h
@@ -38,7 +38,7 @@ class DTreeInterface
 		/**************************************************************** INITIALIZE ****************************************************************/
 
 		//Constructor
-		DTreeInterface(TTree* locTree, bool locIsInputTreeFlag);
+		DTreeInterface(TTree* locTree, bool locIsInputTreeFlag, bool locSaveTLorentzVectorsAsFundamental=false);
 
 		//Set New Tree (e.g. reading a TChain)
 		void Set_NewTree(TTree* locTree);
@@ -158,6 +158,7 @@ class DTreeInterface
 		/************************************************************* MEMBER VARIABLES *************************************************************/
 
 		bool dIsInputTreeFlag;
+		bool dSaveTLorentzVectorsAsFundamental;
 		bool dFirstInputTreeFlag;
 		TTree* dInputTree;
 		map<string, TTree*> dOutputTreeMap;
@@ -205,8 +206,8 @@ class DTreeInterface
 /********************************************************************* INITIALIZE *********************************************************************/
 
 //Constructor
-inline DTreeInterface::DTreeInterface(TTree* locTree, bool locIsInputTreeFlag) :
-	dIsInputTreeFlag(locIsInputTreeFlag), dFirstInputTreeFlag(true),
+inline DTreeInterface::DTreeInterface(TTree* locTree, bool locIsInputTreeFlag, bool locSaveTLorentzVectorsAsFundamental) :
+	dIsInputTreeFlag(locIsInputTreeFlag), dSaveTLorentzVectorsAsFundamental(locSaveTLorentzVectorsAsFundamental), dFirstInputTreeFlag(true),
 	dInputTree(locIsInputTreeFlag ? locTree : NULL)
 {
 	dUpdateGetEntryBranchesFlag = true;
@@ -216,6 +217,8 @@ inline DTreeInterface::DTreeInterface(TTree* locTree, bool locIsInputTreeFlag) :
 	//If input tree is a brand new tree, this function call does nothing.
 	if(dIsInputTreeFlag)
 		Set_BranchAddresses(true);
+
+    if(dSaveTLorentzVectorsAsFundamental) cout << "Saving TLorentzVectors as set of four doubles in flat tree (if flat tree specified)" << endl;
 }
 
 //Set New Tree (e.g. reading a TChain)
@@ -458,29 +461,57 @@ template <typename DType> inline void DTreeInterface::Create_Branch_Fundamental(
 
 template <typename DType> inline void DTreeInterface::Create_Branch_NoSplitTObject(string locBranchName, DType* locMemoryPointer)
 {
-	if(dOutputTreeMap.empty())
-	{
-		cout << "WARNING: CANNOT CREATE BRANCH " << locBranchName << ": OUTPUT TTREE DOES NOT EXIST." << endl;
-		return;
-	}
-	if(dMemoryMap_TObject.find(locBranchName) != dMemoryMap_TObject.end())
-	{
-		cout << "WARNING: CANNOT CREATE BRANCH " << locBranchName << ": IT ALREADY EXISTS." << endl;
-		return;
-	}
+    if(!dSaveTLorentzVectorsAsFundamental) { // Default: save object to ROOT tree
+        if(dOutputTreeMap.empty())
+        {
+            cout << "WARNING: CANNOT CREATE BRANCH " << locBranchName << ": OUTPUT TTREE DOES NOT EXIST." << endl;
+            return;
+        }
+        if(dMemoryMap_TObject.find(locBranchName) != dMemoryMap_TObject.end())
+        {
+            cout << "WARNING: CANNOT CREATE BRANCH " << locBranchName << ": IT ALREADY EXISTS." << endl;
+            return;
+        }
 
-	dMemoryMap_TObject[locBranchName] = static_cast<TObject*>((locMemoryPointer == NULL) ? new DType() : locMemoryPointer);
-	TObject* locTObjectMemoryPointer = dMemoryMap_TObject[locBranchName];
+        dMemoryMap_TObject[locBranchName] = static_cast<TObject*>((locMemoryPointer == NULL) ? new DType() : locMemoryPointer);
+        TObject* locTObjectMemoryPointer = dMemoryMap_TObject[locBranchName];
 
-	string locClassName = dMemoryMap_TObject[locBranchName]->ClassName();
+        string locClassName = dMemoryMap_TObject[locBranchName]->ClassName();
 
-	map<string, TTree*>::const_iterator locIterator = dOutputTreeMap.begin();
-	for(; locIterator != dOutputTreeMap.end(); ++locIterator)
-	{
-		TBranch* locBranch = locIterator->second->Branch(locBranchName.c_str(), locClassName.c_str(), locTObjectMemoryPointer, 32000, 0); //0: don't split
-		if(locIterator == dOutputTreeMap.begin())
-			dBranchMap_OutputTree[locBranchName] = locBranch;
-	}
+        map<string, TTree*>::const_iterator locIterator = dOutputTreeMap.begin();
+        for(; locIterator != dOutputTreeMap.end(); ++locIterator)
+        {
+            TBranch* locBranch = locIterator->second->Branch(locBranchName.c_str(), locClassName.c_str(), locTObjectMemoryPointer, 32000, 0); //0: don't split
+            if(locIterator == dOutputTreeMap.begin())
+                dBranchMap_OutputTree[locBranchName] = locBranch;
+        }
+    }
+
+    if(dSaveTLorentzVectorsAsFundamental) { // Alternative: save input TLorentzVector to four doubles
+        if(locBranchName.find("_p4_")!= std::string::npos) {
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_px");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_py");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_pz");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"__E");
+        }
+        else if(locBranchName.find("_x4_")!= std::string::npos) {
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_x");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_y");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_z");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_t");
+        }
+        else {
+            cout << "WARNING: " << locBranchName << " does not contain _p4_ or _x4_ in branch name. Saving with 4-component names (x1,x2,x3,x0) " << endl;
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_x1");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_x2");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_x3");
+            Create_Branch_Fundamental<Double_t>(locBranchName+"_x0");
+        }
+
+    }
+
+
+
 }
 
 template <typename DType> inline void DTreeInterface::Create_Branch_FundamentalArray(string locBranchName, string locArraySizeString, unsigned int locInitialSize, DType* locMemoryPointer)
@@ -615,7 +646,38 @@ template <typename DType> inline void DTreeInterface::Fill_TObject(string locBra
 
 template <typename DType> inline void DTreeInterface::Fill_TObject(string locBranchName, const DType& locObject)
 {
-	**Get_PointerToPointerTo_TObject<DType>(locBranchName) = locObject;
+    // Determine type of template DType
+    bool locIsTLorentVectorType = std::is_same<DType,TLorentzVector>::value;
+    if(!locIsTLorentVectorType && dSaveTLorentzVectorsAsFundamental) {
+        cout << "WARNING: cannot save branch " << locBranchName << ", type is not TLorentzVector and dSaveTLorentzVectorsAsFundamental is true" << endl;
+        return;
+    }
+
+    if(!dSaveTLorentzVectorsAsFundamental) { // Default: save object to ROOT tree
+        **Get_PointerToPointerTo_TObject<DType>(locBranchName) = locObject;
+    }
+
+    if(dSaveTLorentzVectorsAsFundamental) { // Alternative: if TLorentzVector, save to four doubles
+        TLorentzVector locT4 = (TLorentzVector)locObject;
+        if(locBranchName.find("_p4_")!= std::string::npos) {
+            Fill_Fundamental<Double_t>(locBranchName+"_px",locT4.Px());
+            Fill_Fundamental<Double_t>(locBranchName+"_py",locT4.Py());
+            Fill_Fundamental<Double_t>(locBranchName+"_pz",locT4.Pz());
+            Fill_Fundamental<Double_t>(locBranchName+"__E",locT4.E());
+        }
+        else if(locBranchName.find("_x4_")!= std::string::npos) {
+            Fill_Fundamental<Double_t>(locBranchName+"_x",locT4.X());
+            Fill_Fundamental<Double_t>(locBranchName+"_y",locT4.Y());
+            Fill_Fundamental<Double_t>(locBranchName+"_z",locT4.Z());
+            Fill_Fundamental<Double_t>(locBranchName+"_t",locT4.T());
+        }
+        else {
+            Fill_Fundamental<Double_t>(locBranchName+"_x1",locT4.X());
+            Fill_Fundamental<Double_t>(locBranchName+"_x2",locT4.Y());
+            Fill_Fundamental<Double_t>(locBranchName+"_x3",locT4.Z());
+            Fill_Fundamental<Double_t>(locBranchName+"_x0",locT4.T());
+        }
+    }
 }
 
 /************************************************************** GET BRANCH MEMORY ***********************************************************/

--- a/libraries/DSelector/DTreeInterface.h
+++ b/libraries/DSelector/DTreeInterface.h
@@ -488,13 +488,14 @@ template <typename DType> inline void DTreeInterface::Create_Branch_NoSplitTObje
     }
 
     if(dSaveTLorentzVectorsAsFundamental) { // Alternative: save input TLorentzVector to four doubles
-        if(locBranchName.find("_p4_")!= std::string::npos) {
+		TString locBranchNameTString = locBranchName; //Making case insensitive is easier with TString
+		if(locBranchNameTString.Contains("_p4_",TString::kIgnoreCase)) {
             Create_Branch_Fundamental<Double_t>(locBranchName+"_px");
             Create_Branch_Fundamental<Double_t>(locBranchName+"_py");
             Create_Branch_Fundamental<Double_t>(locBranchName+"_pz");
             Create_Branch_Fundamental<Double_t>(locBranchName+"__E");
         }
-        else if(locBranchName.find("_x4_")!= std::string::npos) {
+        else if(locBranchNameTString.Contains("_x4_",TString::kIgnoreCase)) {
             Create_Branch_Fundamental<Double_t>(locBranchName+"_x");
             Create_Branch_Fundamental<Double_t>(locBranchName+"_y");
             Create_Branch_Fundamental<Double_t>(locBranchName+"_z");

--- a/programs/MakeDSelector/MakeDSelector.cc
+++ b/programs/MakeDSelector/MakeDSelector.cc
@@ -241,6 +241,7 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	dFlatTreeFileName = \"\"; //output flat tree (one combo per tree entry), \"\" for none" << endl;
 	locSourceStream << "	dFlatTreeName = \"\"; //if blank, default name will be chosen" << endl;
 	locSourceStream << "	//dSaveDefaultFlatBranches = true; // False: don't save default branches, reduce disk footprint." << endl;
+	locSourceStream << "	//dSaveTLorentzVectorsAsFundamentaFlatTree = false; // Default (or false): save particles as TLorentzVector objects. True: save as four doubles instead." << endl;
 	locSourceStream << endl;
 	locSourceStream << "	//Because this function gets called for each TTree in the TChain, we must be careful:" << endl;
 	locSourceStream << "		//We need to re-initialize the tree interface & branch wrappers, but don't want to recreate histograms" << endl;
@@ -324,6 +325,9 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "	*/" << endl;
 	locSourceStream << endl;
 	locSourceStream << "	/************************** EXAMPLE USER INITIALIZATION: CUSTOM OUTPUT BRANCHES - FLAT TREE *************************/" << endl;
+	locSourceStream << endl;
+	locSourceStream << "	// RECOMMENDED: CREATE ACCIDENTAL WEIGHT BRANCH" << endl;
+	locSourceStream << "	// dFlatTreeInterface->Create_Branch_Fundamental<Double_t>(\"accidweight\");" << endl;
 	locSourceStream << endl;
 	locSourceStream << "	//EXAMPLE FLAT TREE CUSTOM BRANCHES (OUTPUT ROOT FILE NAME MUST FIRST BE GIVEN!!!! (ABOVE: TOP)):" << endl;
 	locSourceStream << "	//The type for the branch must be included in the brackets" << endl;
@@ -547,7 +551,7 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "		//Double_t locBunchPeriod = dAnalysisUtilities.Get_BeamBunchPeriod(Get_RunNumber());" << endl;
 	locSourceStream << "		// Double_t locDeltaT_RF = dAnalysisUtilities.Get_DeltaT_RF(Get_RunNumber(), locBeamX4_Measured, dComboWrapper);" << endl;
 	locSourceStream << "		// Int_t locRelBeamBucket = dAnalysisUtilities.Get_RelativeBeamBucket(Get_RunNumber(), locBeamX4_Measured, dComboWrapper); // 0 for in-time events, non-zero integer for out-of-time photons" << endl;
-	locSourceStream << "		// Int_t locNumOutOfTimeBunchesInTree = 4; //YOU need to specify this number" << endl;
+	locSourceStream << "		// Int_t locNumOutOfTimeBunchesInTree = XXX; //YOU need to specify this number" << endl;
 	locSourceStream << "			//Number of out-of-time beam bunches in tree (on a single side, so that total number out-of-time bunches accepted is 2 times this number for left + right bunches) " << endl;
 	locSourceStream << endl;
 	locSourceStream << "		// Bool_t locSkipNearestOutOfTimeBunch = true; // True: skip events from nearest out-of-time bunch on either side (recommended)." << endl;
@@ -688,6 +692,9 @@ void Print_SourceFile(string locSelectorBaseName, DTreeInterface* locTreeInterfa
 	locSourceStream << "		//}" << endl;
 	locSourceStream << endl;
 	locSourceStream << "		/****************************************** FILL FLAT TREE (IF DESIRED) ******************************************/" << endl;
+	locSourceStream << endl;
+	locSourceStream << "		// RECOMMENDED: FILL ACCIDENTAL WEIGHT" << endl;
+	locSourceStream << "		// dFlatTreeInterface->Fill_Fundamental<Double_t>(\"accidweight\",locHistAccidWeightFactor);" << endl;
 	locSourceStream << endl;
 	locSourceStream << "		/*" << endl;
 	locSourceStream << "		//FILL ANY CUSTOM BRANCHES FIRST!!" << endl;


### PR DESCRIPTION
…. Individual TLorentzVectors only, arrays of TLorentzVectors not included. Minor additions to MakeDSelector.

I removed the default value of 4 in the line "locNumOutOfTimeBunchesInTree = 4" from MakeDSelector. If anyone happens to be using some other number of beam bunches and isn't careful, they might miss this, now the user will definitely have to specify their number of beam bunches. 