### PR TITLE
add dictionary to proof par file

### DIFF
--- a/programs/MakePROOFPackage/Makefile
+++ b/programs/MakePROOFPackage/Makefile
@@ -17,6 +17,7 @@ all: install
 #LIBRARIES
 .libraries_copied: .directories_made
 	cp ../../${BMS_OSNAME}/lib/libDSelector.so ${DIRNAME}/
+	cp ../../${BMS_OSNAME}/lib/DSelectorDict_rdict.pcm ${DIRNAME}/
 	date > $@
 
 #HEADERS


### PR DESCRIPTION
prevents Cling error messages about not finding the ROOT PCM file and many In-memory ROOT PCM candidates, which showed up after the switch to root 6.24.04