### PR TITLE
add functions to access trigger energy sums

### DIFF
--- a/libraries/DSelector/DSelector.cc
+++ b/libraries/DSelector/DSelector.cc
@@ -93,6 +93,10 @@ void DSelector::Setup_Branches(void)
 	dEventNumber = (ULong64_t*)dTreeInterface->Get_Branch("EventNumber")->GetAddress();
 	TBranch* locL1TriggerBitsBranch = dTreeInterface->Get_Branch("L1TriggerBits");
 	dL1TriggerBits = (locL1TriggerBitsBranch != NULL) ? (UInt_t*)locL1TriggerBitsBranch->GetAddress() : NULL;
+	TBranch* locL1BCALEnergyBranch = dTreeInterface->Get_Branch("L1BCALEnergy");
+	dL1BCALEnergy = (locL1BCALEnergyBranch != NULL) ? (Double_t*)locL1BCALEnergyBranch->GetAddress() : NULL;
+	TBranch* locL1FCALEnergyBranch = dTreeInterface->Get_Branch("L1FCALEnergy");
+	dL1FCALEnergy = (locL1FCALEnergyBranch != NULL) ? (Double_t*)locL1FCALEnergyBranch->GetAddress() : NULL;
 
 	// MC
 	if(locIsMCFlag)

--- a/libraries/DSelector/DSelector.h
+++ b/libraries/DSelector/DSelector.h
@@ -87,6 +87,8 @@ class DSelector : public TSelector
 		UInt_t Get_RunNumber(void) const;
 		ULong64_t Get_EventNumber(void) const;
 		UInt_t Get_L1TriggerBits(void) const;
+		Double_t Get_L1BCALEnergy(void) const;
+		Double_t Get_L1FCALEnergy(void) const;
 		Bool_t Get_IsThrownTopology(void) const;
 		Float_t Get_MCWeight(void) const;
 		Float_t Get_GeneratedEnergy(void) const;
@@ -148,6 +150,8 @@ class DSelector : public TSelector
 		UInt_t* dRunNumber;
 		ULong64_t* dEventNumber;
 		UInt_t* dL1TriggerBits;
+		Double_t* dL1BCALEnergy;
+		Double_t* dL1FCALEnergy;
 		Float_t* dMCWeight; //only present if simulated data
 		Float_t* dGeneratedEnergy; //only present if simulated data
 		Bool_t* dIsThrownTopology; //only present if simulated data
@@ -217,6 +221,16 @@ inline ULong64_t DSelector::Get_EventNumber(void) const
 inline UInt_t DSelector::Get_L1TriggerBits(void) const
 {
 	return *dL1TriggerBits;
+}
+
+inline Double_t DSelector::Get_L1BCALEnergy(void) const
+{
+	return *dL1BCALEnergy;
+}
+
+inline Double_t DSelector::Get_L1FCALEnergy(void) const
+{
+	return *dL1FCALEnergy;
 }
 
 inline Bool_t DSelector::Get_IsThrownTopology(void) const


### PR DESCRIPTION
these data were added to the PART format awhile back, but no functions were added to access them in the DSelector yet.  This PR fixes that oversight.