### PR TITLE
Add code to skip over events without a Physics trigger by default

### DIFF
--- a/libraries/DSelector/DSelector.cc
+++ b/libraries/DSelector/DSelector.cc
@@ -245,6 +245,16 @@ Bool_t DSelector::Process(Long64_t locEntry)
 
 	dTreeInterface->Get_Entry(locEntry);
 
+	// zero out loop indicies if there are no trigger bits set, so that we skip such events
+	// leave this as an togglable option for trigger studies
+	if( (dL1TriggerBits==0) && dSkipNoTriggerEvents) {
+		*dNumBeam = 0;
+		*dNumChargedHypos = 0;
+		*dNumNeutralHypos = 0;
+		*dNumCombos = 0;
+		if(dNumThrown != NULL)  *dNumThrown = 0;
+	}
+
 	return kTRUE;
 }
 

--- a/libraries/DSelector/DSelector.h
+++ b/libraries/DSelector/DSelector.h
@@ -58,6 +58,7 @@ class DSelector : public TSelector
 		string dFlatTreeName; //for output flat trees
 		bool dSaveDefaultFlatBranches; // True by default
 		bool dSaveTLorentzVectorsAsFundamentaFlatTree; // False by default. True: save TLorentzVector info instead as four doubles, rather than as TLorentzVector objects.
+		bool dSkipNoTriggerEvents; // True by default
 
 		//TREE INTERFACE
 		DTreeInterface* dTreeInterface; //for event-based tree
@@ -196,7 +197,8 @@ class DSelector : public TSelector
 /******************************************************************** CONSTRUCTOR *********************************************************************/
 
 inline DSelector::DSelector(TTree* locTree) :
-		 dInitializedFlag(false), dOption(""), dOutputFileName(""), dOutputTreeFileName(""), dFlatTreeFileName(""), dSaveDefaultFlatBranches(true), dSaveTLorentzVectorsAsFundamentaFlatTree(false), dTreeInterface(NULL), dFlatTreeInterface(NULL),
+		 dInitializedFlag(false), dOption(""), dOutputFileName(""), dOutputTreeFileName(""), dFlatTreeFileName(""), dSaveDefaultFlatBranches(true), 
+		 dSaveTLorentzVectorsAsFundamentaFlatTree(false), dSkipNoTriggerEvents(true), dTreeInterface(NULL), dFlatTreeInterface(NULL),
 		dAnalysisUtilities(DAnalysisUtilities()), dTargetCenter(TVector3()), dTargetP4(TLorentzVector()), dTargetPID(Unknown),
 		dThrownBeam(NULL), dThrownWrapper(NULL), dChargedHypoWrapper(NULL), dNeutralHypoWrapper(NULL),
 		dBeamWrapper(NULL), dComboWrapper(NULL), dAnalysisActions(vector<DAnalysisAction*>()),


### PR DESCRIPTION
Back in Aug. 2020, there was a modification to the analysis library to write out MC events that do not pass any physics trigger.  The intention was to help with performing trigger efficiency studies, but this was not fully followed up.

This seems to only affect a small percentage of events, but it should be properly handled in the trees that are currently under analysis. 

One way to go about this would be to ask people to change their DSelector to explicitly reject such events, e.g. skipping events with
`Get_L1TriggerBits() == 0`

Another way would be to modify the DSelector to automatically skip such events.  I think this PR does the latter, by making it so that the usual loops are not performed, by zeroing out the relevant array lengths that are used.  

Whether this is the direction we want to go is something to be discussed...