### PR TITLE
Chi-squared hypothesis tool: Change default matching mode to best combo per beam

### DIFF
--- a/programs/chisq_hypothesis_comparison/config.ini
+++ b/programs/chisq_hypothesis_comparison/config.ini
@@ -24,6 +24,6 @@ tree = pi0pi0__B4_M7_M7
 [Misc]
 ; empty string specifies default output naming convention
 outfile = 5_hypo_comparison_big.root
-best_per_beam = false
+best_per_beam = true
 preserve_combos = true
 logging = false

--- a/programs/chisq_hypothesis_comparison/main.cpp
+++ b/programs/chisq_hypothesis_comparison/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
 
   // optional configs
   std::string out_file = reader.Get("Misc", "outfile", "placeholder");
-  bool best_by_beam = reader.GetBoolean("Misc", "best_per_beam", false);
+  bool best_by_beam = reader.GetBoolean("Misc", "best_per_beam", true);
   bool preserve_combos = reader.GetBoolean("Misc", "preserve_combos", true);
   bool logging = reader.GetBoolean("Misc", "logging", false);
 


### PR DESCRIPTION
Hello! For accidental subtractions, the matching mode should be "best per beam ID". This PR makes that the default, bringing things in line with the `preserve_combos = true` default.